### PR TITLE
Bug/#24

### DIFF
--- a/src/main/java/org/winey/server/controller/FeedController.java
+++ b/src/main/java/org/winey/server/controller/FeedController.java
@@ -38,6 +38,8 @@ public class FeedController {
             @PathVariable Long feedId
     ){
         String imageUrl = feedService.deleteFeed(userId,feedId);
+        //https://s3.ap-northeast-2.amazonaws.com/winey-s3/feed/image/178bdf26-5eb9-449f-8abf-1716c71cd3fa.png
+        //feed/image/178bdf26-5eb9-449f-8abf-1716c71cd3fa.png
         s3Service.deleteFile(imageUrl);
         return ApiResponse.success(Success.DELETE_FEED_SUCCESS);
     }

--- a/src/main/java/org/winey/server/external/client/aws/S3Service.java
+++ b/src/main/java/org/winey/server/external/client/aws/S3Service.java
@@ -110,7 +110,7 @@ public class S3Service {
 
     // 이미지 삭제
     public void deleteFile(String imageUrl) {
-        String imageKey = imageUrl.substring(56);
+        String imageKey = imageUrl.substring(49);
         amazonS3.deleteObject(bucket, imageKey);
     }
 }


### PR DESCRIPTION
## 🚩 관련 이슈
- close #24 

## 📋 구현 기능 명세
- [x] S3 bucket 내에 이미지 삭제 완료!

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
원래 우리가 삭제하면 로컬 db에 있는 이미지 url은 삭제가 되는데 s3 bucket 내의 것들이 삭제 안되는 버그가 있었는데, 해결하게 되었습니다.
우리가 로컬에 저장하는 이미지 url과 s3내의 키 값을 비교해봤더니 다음과 같았습니다.
<img width="454" alt="image" src="https://github.com/team-winey/Winey-Server/assets/49307946/d8c837f1-f399-46a9-a1c6-651cb2564475"> 

그리고 이건 우리가 local에서 피드 전체불러오기 할 때 보였던 url입니다.

`https://s3.ap-northeast-2.amazonaws.com/winey-s3/feed/image/178bdf26-5eb9-449f-8abf-1716c71cd3fa.png`
그래서 subString 값을 우리가 원래 가지고 있던 s3의 인자 값을 바꿔주었더니 해결되었습니다. 😁

- 어떤 부분에 리뷰어가 집중해야 하는지


- 개발하면서 어떤 점이 궁금했는지

## 📸 결과물 스크린샷
<img width="481" alt="image" src="https://github.com/team-winey/Winey-Server/assets/49307946/dc08b29c-84c0-408c-9410-c9d16ed6a742">

## 🛠️ 테스트
- [x] 테스트

## 🚀 API Endpoint
- /feed/{int}
