### PR TITLE
[Feat] HttpRequestMethodNotSupportedException 예외 처리

### DIFF
--- a/src/main/java/org/winey/server/common/advice/ControllerExceptionAdvice.java
+++ b/src/main/java/org/winey/server/common/advice/ControllerExceptionAdvice.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import org.winey.server.common.dto.ApiResponse;
 import org.winey.server.exception.Error;
 import org.winey.server.exception.model.CustomException;
@@ -62,6 +63,12 @@ public class ControllerExceptionAdvice {
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
     protected ApiResponse handleHttpRequestMethodNotSupportedException(final HttpRequestMethodNotSupportedException e) {
         return ApiResponse.error(Error.REQUEST_METHOD_VALIDATION_EXCEPTION, e.getMessage());
+    }
+
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    @ResponseStatus(HttpStatus.PAYLOAD_TOO_LARGE)
+    public ApiResponse fileSizeLimitExceeded(final MaxUploadSizeExceededException e) {
+       return ApiResponse.error(Error.MAX_UPLOAD_SIZE_EXCEED_EXCEPTION, e.getMessage());
     }
 
     /**

--- a/src/main/java/org/winey/server/exception/Error.java
+++ b/src/main/java/org/winey/server/exception/Error.java
@@ -22,6 +22,7 @@ public enum Error {
     NOT_FOUND_CREATED_AT_EXCEPTION(HttpStatus.BAD_REQUEST, "요청한 피드의 생성일이 존재하지 않습니다."),
     PAGE_REQUEST_VALIDATION_EXCEPTION(HttpStatus.BAD_REQUEST, "페이지 넘버가 유효하지 않습니다."),
     REQUEST_METHOD_VALIDATION_EXCEPTION(HttpStatus.BAD_REQUEST, "요청 메소드가 잘못됐습니다."),
+    MAX_UPLOAD_SIZE_EXCEED_EXCEPTION(HttpStatus.PAYLOAD_TOO_LARGE, "파일 용량 초과"),
 
     /**
      * 401 UNAUTHORIZED


### PR DESCRIPTION
## 🚩 관련 이슈
- close #78 

## 📋 구현 기능 명세
- [x] HttpRequestMethodNotSupportedException 예외 처리

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지


- 어떤 부분에 리뷰어가 집중해야 하는지


- 개발하면서 어떤 점이 궁금했는지

## 📸 결과물 스크린샷
```java
@Pattern(regexp = "^[\\S][가-힣a-zA-Z0-9\\s]{0,20}$", message = "위니 피드 제목 형식에 맞지 않습니다.")
```

## 🛠️ 테스트
- [x] 테스트

## 🚀 API Endpoint
- /
