### PR TITLE
[Feat] 유저 인증 애너테이션, 토큰 재발급, 로그아웃

### DIFF
--- a/src/main/java/org/winey/server/config/WebConfig.java
+++ b/src/main/java/org/winey/server/config/WebConfig.java
@@ -1,0 +1,21 @@
+package org.winey.server.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.winey.server.config.resolver.UserIdResolver;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    private final UserIdResolver userIdResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(userIdResolver);
+    }
+}

--- a/src/main/java/org/winey/server/config/jwt/JwtService.java
+++ b/src/main/java/org/winey/server/config/jwt/JwtService.java
@@ -5,6 +5,7 @@ import io.jsonwebtoken.security.Keys;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.winey.server.exception.Error;
+import org.winey.server.exception.model.NotFoundException;
 import org.winey.server.exception.model.UnauthorizedException;
 
 import javax.annotation.PostConstruct;
@@ -59,7 +60,8 @@ public class JwtService {
             if (e instanceof ExpiredJwtException) {
                 throw new UnauthorizedException(Error.TOKEN_TIME_EXPIRED_EXCEPTION, Error.TOKEN_TIME_EXPIRED_EXCEPTION.getMessage());
             }
-            return false;
+            throw new NotFoundException(Error.NOT_FOUND_USER_EXCEPTION, Error.NOT_FOUND_USER_EXCEPTION.getMessage());
+//            return false;
         }
     }
 

--- a/src/main/java/org/winey/server/config/resolver/UserId.java
+++ b/src/main/java/org/winey/server/config/resolver/UserId.java
@@ -1,0 +1,11 @@
+package org.winey.server.config.resolver;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface UserId {
+}

--- a/src/main/java/org/winey/server/config/resolver/UserIdResolver.java
+++ b/src/main/java/org/winey/server/config/resolver/UserIdResolver.java
@@ -26,7 +26,7 @@ public class UserIdResolver implements HandlerMethodArgumentResolver {
     @Override
     public Object resolveArgument(@NotNull MethodParameter parameter, ModelAndViewContainer modelAndViewContainer, @NotNull NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
         final HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
-        final String token = request.getHeader("accessToken");
+        final String token = request.getHeader("token");
 
         // 토큰 검증
         if (!jwtService.verifyToken(token)) {

--- a/src/main/java/org/winey/server/config/resolver/UserIdResolver.java
+++ b/src/main/java/org/winey/server/config/resolver/UserIdResolver.java
@@ -26,7 +26,7 @@ public class UserIdResolver implements HandlerMethodArgumentResolver {
     @Override
     public Object resolveArgument(@NotNull MethodParameter parameter, ModelAndViewContainer modelAndViewContainer, @NotNull NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
         final HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
-        final String token = request.getHeader("token");
+        final String token = request.getHeader("accessToken");
 
         // 토큰 검증
         if (!jwtService.verifyToken(token)) {

--- a/src/main/java/org/winey/server/config/resolver/UserIdResolver.java
+++ b/src/main/java/org/winey/server/config/resolver/UserIdResolver.java
@@ -1,0 +1,44 @@
+package org.winey.server.config.resolver;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import org.winey.server.config.jwt.JwtService;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.validation.constraints.NotNull;
+
+@RequiredArgsConstructor
+@Component
+public class UserIdResolver implements HandlerMethodArgumentResolver {
+
+    private final JwtService jwtService;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(UserId.class) && Long.class.equals(parameter.getParameterType());
+    }
+
+    @Override
+    public Object resolveArgument(@NotNull MethodParameter parameter, ModelAndViewContainer modelAndViewContainer, @NotNull NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        final HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        final String token = request.getHeader("accessToken");
+
+        // 토큰 검증
+        if (!jwtService.verifyToken(token)) {
+            throw new RuntimeException(String.format("USER_ID를 가져오지 못했습니다. (%s - %s)", parameter.getClass(), parameter.getMethod()));
+        }
+
+        // 유저 아이디 반환
+        final String tokenContents = jwtService.getJwtContents(token);
+        try {
+            return Long.parseLong(tokenContents);
+        } catch (NumberFormatException e) {
+            throw new RuntimeException(String.format("USER_ID를 가져오지 못했습니다. (%s - %s)", parameter.getClass(), parameter.getMethod()));
+        }
+    }
+}

--- a/src/main/java/org/winey/server/controller/AuthController.java
+++ b/src/main/java/org/winey/server/controller/AuthController.java
@@ -25,4 +25,10 @@ public class AuthController {
             ) {
         return ApiResponse.success(Success.LOGIN_SUCCESS, authService.signIn(socialAccessToken, requestDto));
     }
+
+    @PostMapping("/token")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponse getAccessToken(@RequestHeader String refreshToken) {
+        return ApiResponse.success(Success.GET_ACCESS_TOKEN_SUCCESS, authService.getAccessToken(refreshToken));
+    }
 }

--- a/src/main/java/org/winey/server/controller/AuthController.java
+++ b/src/main/java/org/winey/server/controller/AuthController.java
@@ -33,4 +33,11 @@ public class AuthController {
     public ApiResponse<TokenResponseDto> reissueToken(@UserId Long userId) {
         return ApiResponse.success(Success.RE_ISSUE_TOKEN_SUCCESS, authService.issueToken(userId));
     }
+
+    @PostMapping("/sign-out")
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponse signOut(@UserId Long userId) {
+        authService.signOut(userId);
+        return ApiResponse.success(Success.SIGNOUT_SUCCESS);
+    }
 }

--- a/src/main/java/org/winey/server/controller/AuthController.java
+++ b/src/main/java/org/winey/server/controller/AuthController.java
@@ -30,8 +30,8 @@ public class AuthController {
 
     @PostMapping("/token")
     @ResponseStatus(HttpStatus.OK)
-    public ApiResponse<TokenResponseDto> reissueToken(@UserId Long userId) {
-        return ApiResponse.success(Success.RE_ISSUE_TOKEN_SUCCESS, authService.issueToken(userId));
+    public ApiResponse<TokenResponseDto> reissueToken(@RequestHeader String refreshToken) {
+        return ApiResponse.success(Success.RE_ISSUE_TOKEN_SUCCESS, authService.issueToken(refreshToken));
     }
 
     @PostMapping("/sign-out")

--- a/src/main/java/org/winey/server/controller/AuthController.java
+++ b/src/main/java/org/winey/server/controller/AuthController.java
@@ -5,8 +5,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.winey.server.common.dto.ApiResponse;
+import org.winey.server.config.resolver.UserId;
 import org.winey.server.controller.request.auth.SignInRequestDto;
 import org.winey.server.controller.response.auth.SignInResponseDto;
+import org.winey.server.controller.response.auth.TokenResponseDto;
 import org.winey.server.exception.Success;
 import org.winey.server.service.auth.AuthService;
 
@@ -28,7 +30,7 @@ public class AuthController {
 
     @PostMapping("/token")
     @ResponseStatus(HttpStatus.OK)
-    public ApiResponse getAccessToken(@RequestHeader String refreshToken) {
-        return ApiResponse.success(Success.GET_ACCESS_TOKEN_SUCCESS, authService.getAccessToken(refreshToken));
+    public ApiResponse<TokenResponseDto> reissueToken(@UserId Long userId) {
+        return ApiResponse.success(Success.RE_ISSUE_TOKEN_SUCCESS, authService.issueToken(userId));
     }
 }

--- a/src/main/java/org/winey/server/controller/FeedController.java
+++ b/src/main/java/org/winey/server/controller/FeedController.java
@@ -37,7 +37,7 @@ public class FeedController {
             BindingResult bindingResult) {
 
         if (bindingResult.hasErrors()) {
-            return ApiResponse.error(Error.MAX_AMOUNT_VALIDATION_EXCEPTION, Error.MAX_AMOUNT_VALIDATION_EXCEPTION.getMessage());
+            return ApiResponse.error(Error.REQUEST_VALIDATION_EXCEPTION, Error.REQUEST_VALIDATION_EXCEPTION.getMessage());
         }
 
         String feedImageUrl = s3Service.uploadImage(request.getFeedImage(), "feed");

--- a/src/main/java/org/winey/server/controller/FeedController.java
+++ b/src/main/java/org/winey/server/controller/FeedController.java
@@ -9,6 +9,7 @@ import org.springframework.validation.BindingResult;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.winey.server.common.dto.ApiResponse;
+import org.winey.server.config.resolver.UserId;
 import org.winey.server.controller.request.CreateFeedRequestDto;
 import org.winey.server.controller.response.feed.CreateFeedResponseDto;
 import org.winey.server.controller.response.feed.GetAllFeedResponseDto;
@@ -32,7 +33,7 @@ public class FeedController {
     @ResponseStatus(HttpStatus.CREATED)
     @Operation(summary = "위니 피드 생성 API", description = "위니 피드를 서버에 등록합니다.")
     public ApiResponse<CreateFeedResponseDto> createFeed(
-            @RequestHeader("userId") Long userId,
+            @UserId Long userId,
             @Valid @ModelAttribute final CreateFeedRequestDto request,
             BindingResult bindingResult) {
 
@@ -48,7 +49,7 @@ public class FeedController {
     @ResponseStatus(HttpStatus.OK)
     @Operation(summary = "위니 피드 삭제 API", description = "위니 피드를 서버에서 삭제합니다.")
     public ApiResponse deleteFeed(
-            @RequestHeader("userId") Long userId,
+            @UserId Long userId,
             @PathVariable Long feedId
     ) {
         String imageUrl = feedService.deleteFeed(userId, feedId);
@@ -59,7 +60,7 @@ public class FeedController {
     @GetMapping("")
     @ResponseStatus(HttpStatus.OK)
     @Operation(summary = "위니 피드 전체 조회 API", description = "위니 피드 전체를 조회합니다.")
-    public ApiResponse<GetAllFeedResponseDto> getAllFeed(@RequestParam int page, @RequestHeader Long userId) {
+    public ApiResponse<GetAllFeedResponseDto> getAllFeed(@RequestParam int page, @UserId Long userId) {
         if (page < 1)
             return ApiResponse.error(Error.PAGE_REQUEST_VALIDATION_EXCEPTION, Error.PAGE_REQUEST_VALIDATION_EXCEPTION.getMessage());
         return ApiResponse.success(Success.GET_FEED_LIST_SUCCESS, feedService.getAllFeed(page, userId));
@@ -68,7 +69,7 @@ public class FeedController {
     @GetMapping("/myFeed")
     @ResponseStatus(HttpStatus.OK)
     @Operation(summary = "마이 피드 조회 API", description = "마이 피드를 조회합니다.")
-    public ApiResponse<GetAllFeedResponseDto> getMyFeed(@RequestParam int page, @RequestHeader Long userId) {
+    public ApiResponse<GetAllFeedResponseDto> getMyFeed(@RequestParam int page, @UserId Long userId) {
         if (page < 1)
             return ApiResponse.error(Error.PAGE_REQUEST_VALIDATION_EXCEPTION, Error.PAGE_REQUEST_VALIDATION_EXCEPTION.getMessage());
         return ApiResponse.success(Success.GET_MYFEED_SUCCESS, feedService.getMyFeed(page, userId));

--- a/src/main/java/org/winey/server/controller/FeedLikeController.java
+++ b/src/main/java/org/winey/server/controller/FeedLikeController.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.winey.server.common.dto.ApiResponse;
+import org.winey.server.config.resolver.UserId;
 import org.winey.server.controller.request.feedLike.CreateFeedLikeRequestDto;
 import org.winey.server.controller.response.feedLike.CreateFeedLikeResponseDto;
 import org.winey.server.exception.Success;
@@ -24,7 +25,7 @@ public class FeedLikeController {
     @ResponseStatus(HttpStatus.OK)
     @Operation(summary = "좋아요를 만드는 API", description = "피드의 좋아요를 생성합니다.")
     public ApiResponse<CreateFeedLikeResponseDto> createFeedLike(
-            @RequestHeader Long userId,
+            @UserId Long userId,
             @PathVariable Long feedId,
             @RequestBody @Valid CreateFeedLikeRequestDto requestDto
     ) {

--- a/src/main/java/org/winey/server/controller/GoalController.java
+++ b/src/main/java/org/winey/server/controller/GoalController.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.winey.server.common.dto.ApiResponse;
+import org.winey.server.config.resolver.UserId;
 import org.winey.server.controller.request.goal.GoalRequestCreateDto;
 import org.winey.server.controller.response.goal.GoalResponseCreateDto;
 import org.winey.server.exception.Success;
@@ -25,7 +26,7 @@ public class GoalController {
     @PostMapping("")
     @ResponseStatus(HttpStatus.CREATED)
     @Operation(summary = "목표 생성 API", description = "위니 목표를 설정합니다.")
-    public ApiResponse<GoalResponseCreateDto> create(@RequestBody @Valid final GoalRequestCreateDto requestDto, @RequestHeader Long userId) {
+    public ApiResponse<GoalResponseCreateDto> create(@RequestBody @Valid final GoalRequestCreateDto requestDto, @UserId Long userId) {
         return ApiResponse.success(Success.CREATE_GOAL_SUCCESS, goalService.createGoal(requestDto, userId));
     }
 }

--- a/src/main/java/org/winey/server/controller/UserController.java
+++ b/src/main/java/org/winey/server/controller/UserController.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.winey.server.common.dto.ApiResponse;
+import org.winey.server.config.resolver.UserId;
 import org.winey.server.controller.response.user.UserResponseDto;
 import org.winey.server.exception.Success;
 import org.winey.server.service.UserService;
@@ -21,7 +22,7 @@ public class UserController {
     @GetMapping("")
     @ResponseStatus(HttpStatus.OK)
     @Operation(summary = "마이페이지 API", description = "유저의 마이페이지를 조회합니다.")
-    public ApiResponse<UserResponseDto> getUser(@RequestHeader Long userId) {
+    public ApiResponse<UserResponseDto> getUser(@UserId Long userId) {
         return ApiResponse.success(Success.GET_USER_SUCCESS, userService.getUser(userId));
     }
 }

--- a/src/main/java/org/winey/server/controller/response/auth/TokenResponseDto.java
+++ b/src/main/java/org/winey/server/controller/response/auth/TokenResponseDto.java
@@ -1,0 +1,18 @@
+package org.winey.server.controller.response.auth;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class TokenResponseDto {
+    private String accessToken;
+    private String refreshToken;
+
+    public static TokenResponseDto of(String accessToken, String refreshToken) {
+        return new TokenResponseDto(accessToken, refreshToken);
+    }
+}

--- a/src/main/java/org/winey/server/exception/Success.java
+++ b/src/main/java/org/winey/server/exception/Success.java
@@ -17,12 +17,12 @@ public enum Success {
     GET_USER_SUCCESS(HttpStatus.OK, "유저 조회 성공"),
     GET_MYFEED_SUCCESS(HttpStatus.OK, "마이 피드 조회 성공"),
     RE_ISSUE_TOKEN_SUCCESS(HttpStatus.OK, "토큰 재발급 성공"),
-
     /**
      * 201 CREATED
      */
     LOGIN_SUCCESS(HttpStatus.OK, "로그인에 성공했습니다."),
     SIGNUP_SUCCESS(HttpStatus.CREATED, "회원가입이 완료됐습니다."),
+    SIGNOUT_SUCCESS(HttpStatus.CREATED, "로그아웃이 완료됐습니다."),
     CREATE_BOARD_SUCCESS(HttpStatus.CREATED, "게시물 생성이 완료됐습니다."),
     CREATE_GOAL_SUCCESS(HttpStatus.CREATED, "목표 생성이 완료됐습니다."),
     CREATE_FEED_RESPONSE_SUCCESS(HttpStatus.CREATED, "피드 반응 생성이 완료됐습니다."),

--- a/src/main/java/org/winey/server/exception/Success.java
+++ b/src/main/java/org/winey/server/exception/Success.java
@@ -16,6 +16,7 @@ public enum Success {
     GET_FEED_LIST_SUCCESS(HttpStatus.OK, "피드 전체 조회 성공"),
     GET_USER_SUCCESS(HttpStatus.OK, "유저 조회 성공"),
     GET_MYFEED_SUCCESS(HttpStatus.OK, "마이 피드 조회 성공"),
+    GET_ACCESS_TOKEN_SUCCESS(HttpStatus.OK, "액세스 토큰 발급 성공"),
 
     /**
      * 201 CREATED

--- a/src/main/java/org/winey/server/exception/Success.java
+++ b/src/main/java/org/winey/server/exception/Success.java
@@ -16,7 +16,7 @@ public enum Success {
     GET_FEED_LIST_SUCCESS(HttpStatus.OK, "피드 전체 조회 성공"),
     GET_USER_SUCCESS(HttpStatus.OK, "유저 조회 성공"),
     GET_MYFEED_SUCCESS(HttpStatus.OK, "마이 피드 조회 성공"),
-    GET_ACCESS_TOKEN_SUCCESS(HttpStatus.OK, "액세스 토큰 발급 성공"),
+    RE_ISSUE_TOKEN_SUCCESS(HttpStatus.OK, "토큰 재발급 성공"),
 
     /**
      * 201 CREATED

--- a/src/main/java/org/winey/server/infrastructure/UserRepository.java
+++ b/src/main/java/org/winey/server/infrastructure/UserRepository.java
@@ -17,6 +17,8 @@ public interface UserRepository extends Repository<User, Long> {
 
     Optional<User> findBySocialIdAndSocialType(String socialId, SocialType socialType);
 
+    Optional<User> findByRefreshToken(String refreshToken);
+
 
 
     // UPDATE

--- a/src/main/java/org/winey/server/service/auth/AuthService.java
+++ b/src/main/java/org/winey/server/service/auth/AuthService.java
@@ -66,6 +66,13 @@ public class AuthService {
         return TokenResponseDto.of(accessToken, refreshToken);
     }
 
+    @Transactional
+    public void signOut(Long userId) {
+        User user = userRepository.findByUserId(userId)
+                .orElseThrow(() -> new NotFoundException(Error.NOT_FOUND_USER_EXCEPTION, Error.NOT_FOUND_USER_EXCEPTION.getMessage()));
+        user.updateRefreshToken(null);
+    }
+
     private String login(SocialType socialType, String socialAccessToken) {
         if (socialType.toString() == "APPLE") {
             return appleSignInService.getAppleId(socialAccessToken);

--- a/src/main/java/org/winey/server/service/auth/AuthService.java
+++ b/src/main/java/org/winey/server/service/auth/AuthService.java
@@ -51,6 +51,14 @@ public class AuthService {
         return SignInResponseDto.of(user.getUserId(), accessToken, refreshToken, isRegistered);
     }
 
+    @Transactional
+    public String getAccessToken(String refreshToken) {
+        User user = userRepository.findByRefreshToken(refreshToken)
+                .orElseThrow(() -> new NotFoundException(Error.NOT_FOUND_USER_EXCEPTION, Error.NOT_FOUND_USER_EXCEPTION.getMessage()));
+
+        return jwtService.issuedToken(String.valueOf(user.getUserId()), TOKEN_EXPIRATION_TIME_ACCESS);
+    }
+
     private String login(SocialType socialType, String socialAccessToken) {
         if (socialType.toString() == "APPLE") {
             return appleSignInService.getAppleId(socialAccessToken);

--- a/src/main/java/org/winey/server/service/auth/AuthService.java
+++ b/src/main/java/org/winey/server/service/auth/AuthService.java
@@ -53,23 +53,26 @@ public class AuthService {
     }
 
     @Transactional
-    public TokenResponseDto issueToken(Long userId) {
-        User user = userRepository.findByUserId(userId)
+    public TokenResponseDto issueToken(String refreshToken) {
+        jwtService.verifyToken(refreshToken);
+
+        User user = userRepository.findByRefreshToken(refreshToken)
                 .orElseThrow(() -> new NotFoundException(Error.NOT_FOUND_USER_EXCEPTION, Error.NOT_FOUND_USER_EXCEPTION.getMessage()));
 
         // jwt 발급 (액세스 토큰, 리프레쉬 토큰)
-        String accessToken = jwtService.issuedToken(String.valueOf(user.getUserId()), TOKEN_EXPIRATION_TIME_ACCESS);
-        String refreshToken = jwtService.issuedToken(String.valueOf(user.getUserId()), TOKEN_EXPIRATION_TIME_REFRESH);
+        String newAccessToken = jwtService.issuedToken(String.valueOf(user.getUserId()), TOKEN_EXPIRATION_TIME_ACCESS);
+        String newRefreshToken = jwtService.issuedToken(String.valueOf(user.getUserId()), TOKEN_EXPIRATION_TIME_REFRESH);
 
-        user.updateRefreshToken(refreshToken);
+        user.updateRefreshToken(newRefreshToken);
 
-        return TokenResponseDto.of(accessToken, refreshToken);
+        return TokenResponseDto.of(newAccessToken, newRefreshToken);
     }
 
     @Transactional
     public void signOut(Long userId) {
         User user = userRepository.findByUserId(userId)
                 .orElseThrow(() -> new NotFoundException(Error.NOT_FOUND_USER_EXCEPTION, Error.NOT_FOUND_USER_EXCEPTION.getMessage()));
+
         user.updateRefreshToken(null);
     }
 


### PR DESCRIPTION
## 🚩 관련 이슈
- close #90 

## 📋 구현 기능 명세
- [x] 유저 인증 애너테이션
 requestHeader에 `accessToken`을 읽어 user Id 값으로 자동 변환하게 했습니다!
- [x] 토큰 재발급
 requestHeader를 통해 `refreshToken`을 받고 해당 토큰의 유효성 검사를 마친 후 refreshToken으로 유저 찾기 -> 토큰 재발급 -> refreshToken 업데이트
- [x] 로그아웃
유저 db의 refreshToken null로 업데이트!

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지


- 어떤 부분에 리뷰어가 집중해야 하는지


- 개발하면서 어떤 점이 궁금했는지

## 📸 결과물 스크린샷
```java
@Pattern(regexp = "^[\\S][가-힣a-zA-Z0-9\\s]{0,20}$", message = "위니 피드 제목 형식에 맞지 않습니다.")
```

## 🛠️ 테스트
- [x] 테스트

## 🚀 API Endpoint
- /
