### PR TITLE
[Feat] 닉네임 수정 API

### DIFF
--- a/src/main/java/org/winey/server/controller/UserController.java
+++ b/src/main/java/org/winey/server/controller/UserController.java
@@ -15,6 +15,8 @@ import org.winey.server.exception.model.ConflictException;
 import org.winey.server.service.UserService;
 
 import javax.validation.Valid;
+import java.util.HashMap;
+import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
@@ -40,5 +42,17 @@ public class UserController {
         }
         userService.updateNickname(userId, requestDto);
         return ApiResponse.success(Success.UPDATE_NICKNAME_SUCCESS);
+    }
+
+    @GetMapping("/nickname/is-exist")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "닉네임 중복 확인 API", description = "닉네임 중복을 확인합니다.")
+    public ApiResponse checkNicknameDuplicate(@RequestParam String nickname) {
+        Map<String, Boolean> result = new HashMap<String, Boolean>() {
+            {
+                put("isDuplicated", userService.checkNicknameDuplicate(nickname));
+            }
+        };
+        return ApiResponse.success(Success.CHECK_NICKNAME_DUPLICATE_SUCCESS, result);
     }
 }

--- a/src/main/java/org/winey/server/controller/UserController.java
+++ b/src/main/java/org/winey/server/controller/UserController.java
@@ -7,9 +7,14 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.winey.server.common.dto.ApiResponse;
 import org.winey.server.config.resolver.UserId;
+import org.winey.server.controller.request.UpdateUserNicknameDto;
 import org.winey.server.controller.response.user.UserResponseDto;
+import org.winey.server.exception.Error;
 import org.winey.server.exception.Success;
+import org.winey.server.exception.model.ConflictException;
 import org.winey.server.service.UserService;
+
+import javax.validation.Valid;
 
 @RestController
 @RequiredArgsConstructor
@@ -19,10 +24,21 @@ public class UserController {
 
     private final UserService userService;
 
-    @GetMapping("")
+    @GetMapping
     @ResponseStatus(HttpStatus.OK)
     @Operation(summary = "마이페이지 API", description = "유저의 마이페이지를 조회합니다.")
     public ApiResponse<UserResponseDto> getUser(@UserId Long userId) {
         return ApiResponse.success(Success.GET_USER_SUCCESS, userService.getUser(userId));
+    }
+
+    @PatchMapping("/nickname")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "닉네임 변경 API", description = "유저의 닉네임을 변경합니다.")
+    public ApiResponse updateNickname (@UserId Long userId, @RequestBody @Valid final UpdateUserNicknameDto requestDto) {
+        if (userService.checkNicknameDuplicate(requestDto.getNickname())) {
+            throw new ConflictException(Error.ALREADY_EXIST_NICKNAME_EXCEPTION, Error.ALREADY_EXIST_NICKNAME_EXCEPTION.getMessage());
+        }
+        userService.updateNickname(userId, requestDto);
+        return ApiResponse.success(Success.UPDATE_NICKNAME_SUCCESS);
     }
 }

--- a/src/main/java/org/winey/server/controller/request/UpdateUserNicknameDto.java
+++ b/src/main/java/org/winey/server/controller/request/UpdateUserNicknameDto.java
@@ -1,0 +1,16 @@
+package org.winey.server.controller.request;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class UpdateUserNicknameDto {
+    @NotNull
+    private String nickname;
+}

--- a/src/main/java/org/winey/server/domain/user/User.java
+++ b/src/main/java/org/winey/server/domain/user/User.java
@@ -58,4 +58,8 @@ public class User extends AuditingTimeEntity {
     public void updateRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;
     }
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
 }

--- a/src/main/java/org/winey/server/exception/Error.java
+++ b/src/main/java/org/winey/server/exception/Error.java
@@ -55,7 +55,7 @@ public enum Error {
      * 409 CONFLICT
      */
     ALREADY_EXIST_USER_EXCEPTION(HttpStatus.CONFLICT, "이미 존재하는 유저입니다"),
-
+    ALREADY_EXIST_NICKNAME_EXCEPTION(HttpStatus.CONFLICT, "이미 존재하는 닉네임입니다"),
 
     /**
      * 500 INTERNAL SERVER ERROR

--- a/src/main/java/org/winey/server/exception/Success.java
+++ b/src/main/java/org/winey/server/exception/Success.java
@@ -17,6 +17,7 @@ public enum Success {
     GET_USER_SUCCESS(HttpStatus.OK, "유저 조회 성공"),
     GET_MYFEED_SUCCESS(HttpStatus.OK, "마이 피드 조회 성공"),
     RE_ISSUE_TOKEN_SUCCESS(HttpStatus.OK, "토큰 재발급 성공"),
+    UPDATE_NICKNAME_SUCCESS(HttpStatus.OK, "닉네임 변경 성공"),
     /**
      * 201 CREATED
      */

--- a/src/main/java/org/winey/server/exception/Success.java
+++ b/src/main/java/org/winey/server/exception/Success.java
@@ -18,6 +18,7 @@ public enum Success {
     GET_MYFEED_SUCCESS(HttpStatus.OK, "마이 피드 조회 성공"),
     RE_ISSUE_TOKEN_SUCCESS(HttpStatus.OK, "토큰 재발급 성공"),
     UPDATE_NICKNAME_SUCCESS(HttpStatus.OK, "닉네임 변경 성공"),
+    CHECK_NICKNAME_DUPLICATE_SUCCESS(HttpStatus.OK, "닉네임 중복 확인 성공"),
     /**
      * 201 CREATED
      */

--- a/src/main/java/org/winey/server/infrastructure/UserRepository.java
+++ b/src/main/java/org/winey/server/infrastructure/UserRepository.java
@@ -19,6 +19,7 @@ public interface UserRepository extends Repository<User, Long> {
 
     Optional<User> findByRefreshToken(String refreshToken);
 
+    Boolean existsByNickname(String nickname);
 
 
     // UPDATE

--- a/src/main/java/org/winey/server/service/UserService.java
+++ b/src/main/java/org/winey/server/service/UserService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.joda.time.LocalDateTime;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.winey.server.controller.request.UpdateUserNicknameDto;
 import org.winey.server.controller.response.user.UserResponseDto;
 import org.winey.server.controller.response.user.UserResponseGoalDto;
 import org.winey.server.controller.response.user.UserResponseUserDto;
@@ -45,5 +46,17 @@ public class UserService {
         int dDay = (int) ChronoUnit.DAYS.between(LocalDate.now(), presentGoal.getTargetDate());
         UserResponseGoalDto goalDto = UserResponseGoalDto.of(presentGoal.getDuringGoalAmount(), presentGoal.getDuringGoalCount(), presentGoal.getTargetMoney(), targetDay, dDay, LocalDate.now().isAfter(presentGoal.getTargetDate()), presentGoal.isAttained());
         return UserResponseDto.of(userDto, goalDto);
+    }
+
+    @Transactional
+    public void updateNickname(Long userId, UpdateUserNicknameDto requestDto) {
+        User user = userRepository.findByUserId(userId)
+                .orElseThrow(() -> new NotFoundException(Error.NOT_FOUND_USER_EXCEPTION, Error.NOT_FOUND_USER_EXCEPTION.getMessage()));
+
+        user.updateNickname(requestDto.getNickname());
+    }
+
+    public Boolean checkNicknameDuplicate(String nickname) {
+        return userRepository.existsByNickname(nickname);
     }
 }


### PR DESCRIPTION
## 🚩 관련 이슈
- close #95 

## 📋 구현 기능 명세
- [x] 닉네임 수정 API
- [x] 닉네임 중복 체크 API
- [x] 닉네임 중복 체크 

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지


- 어떤 부분에 리뷰어가 집중해야 하는지
닉네임 중복 체크 먼저 하고 닉네임 변경하도록 코드 작성하였습니다!

닉네임 중복체크 API 보시면 응답값을 map으로 감싸서 주고 있어요..! DTO까지 만들어야 하나 해서..! 좋은 의견 있으시면 주세용 :)
- 개발하면서 어떤 점이 궁금했는지

## 📸 결과물 스크린샷
```java
@Pattern(regexp = "^[\\S][가-힣a-zA-Z0-9\\s]{0,20}$", message = "위니 피드 제목 형식에 맞지 않습니다.")
```

## 🛠️ 테스트
- [x] 테스트

## 🚀 API Endpoint
- /
