### PR TITLE
Feat/#100

### DIFF
--- a/src/main/java/org/winey/server/controller/CommentController.java
+++ b/src/main/java/org/winey/server/controller/CommentController.java
@@ -35,4 +35,15 @@ public class CommentController {
         return ApiResponse.success(Success.CREATE_COMMENT_RESPONSE_SUCCESS, commentService.createComment(userId, feedId, requestDto.getContent()));
     }
 
+    @DeleteMapping(value = "/{commentId}")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "댓글 삭제 API", description = "피드의 댓글을 삭제합니다.")
+    public ApiResponse deleteComment(
+            @UserId Long userId,
+            @PathVariable Long commentId
+    ) {
+        commentService.deleteComment(userId, commentId);
+        return ApiResponse.success(Success.DELETE_COMMENT_SUCCESS);
+    }
+
 }

--- a/src/main/java/org/winey/server/controller/CommentController.java
+++ b/src/main/java/org/winey/server/controller/CommentController.java
@@ -25,7 +25,7 @@ public class CommentController {
     private final CommentService commentService;
 
     @PostMapping(value = "/{feedId}")
-    @ResponseStatus(HttpStatus.OK)
+    @ResponseStatus(HttpStatus.CREATED)
     @Operation(summary = "댓글을 만드는 API", description = "피드의 댓글을 생성합니다.")
     public ApiResponse<CreateCommentResponseDto> createComment(
             @UserId Long userId,

--- a/src/main/java/org/winey/server/controller/CommentController.java
+++ b/src/main/java/org/winey/server/controller/CommentController.java
@@ -1,0 +1,38 @@
+package org.winey.server.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import org.winey.server.common.dto.ApiResponse;
+import org.winey.server.config.resolver.UserId;
+import org.winey.server.controller.request.comment.CreateCommentRequestDto;
+import org.winey.server.controller.request.feedLike.CreateFeedLikeRequestDto;
+import org.winey.server.controller.response.comment.CreateCommentResponseDto;
+import org.winey.server.controller.response.feedLike.CreateFeedLikeResponseDto;
+import org.winey.server.exception.Success;
+import org.winey.server.service.CommentService;
+import org.winey.server.service.FeedLikeService;
+
+import javax.validation.Valid;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/comment")
+@Tag(name = "Comment 댓글", description = "위니 피드 댓글 API Document")
+public class CommentController {
+    private final CommentService commentService;
+
+    @PostMapping(value = "/{feedId}")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "댓글을 만드는 API", description = "피드의 댓글을 생성합니다.")
+    public ApiResponse<CreateCommentResponseDto> createComment(
+            @UserId Long userId,
+            @PathVariable Long feedId,
+            @RequestBody @Valid CreateCommentRequestDto requestDto
+    ) {
+        return ApiResponse.success(Success.CREATE_COMMENT_RESPONSE_SUCCESS, commentService.createComment(userId, feedId, requestDto.getContent()));
+    }
+
+}

--- a/src/main/java/org/winey/server/controller/request/comment/CreateCommentRequestDto.java
+++ b/src/main/java/org/winey/server/controller/request/comment/CreateCommentRequestDto.java
@@ -1,0 +1,16 @@
+package org.winey.server.controller.request.comment;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class CreateCommentRequestDto {
+    @NotNull
+    private String content;
+}

--- a/src/main/java/org/winey/server/controller/request/comment/CreateCommentRequestDto.java
+++ b/src/main/java/org/winey/server/controller/request/comment/CreateCommentRequestDto.java
@@ -6,11 +6,13 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor
 public class CreateCommentRequestDto {
     @NotNull
+    @Size(max = 500, message = "댓글은 500자 이하여야 합니다.")
     private String content;
 }

--- a/src/main/java/org/winey/server/controller/response/comment/CreateCommentResponseDto.java
+++ b/src/main/java/org/winey/server/controller/response/comment/CreateCommentResponseDto.java
@@ -1,0 +1,21 @@
+package org.winey.server.controller.response.comment;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.winey.server.controller.response.feedLike.CreateFeedLikeResponseDto;
+import org.winey.server.domain.user.User;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class CreateCommentResponseDto {
+    private Long feedId;
+    private Long commentCounter;
+    private User author;
+
+    public static CreateCommentResponseDto of(Long feedId, Long commentCounter,User author) {
+        return new CreateCommentResponseDto(feedId, commentCounter,author);
+    }
+}

--- a/src/main/java/org/winey/server/controller/response/comment/CreateCommentResponseDto.java
+++ b/src/main/java/org/winey/server/controller/response/comment/CreateCommentResponseDto.java
@@ -11,11 +11,11 @@ import org.winey.server.domain.user.User;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class CreateCommentResponseDto {
-    private Long feedId;
+    private Long commentId;
     private Long commentCounter;
     private User author;
 
-    public static CreateCommentResponseDto of(Long feedId, Long commentCounter,User author) {
-        return new CreateCommentResponseDto(feedId, commentCounter,author);
+    public static CreateCommentResponseDto of(Long commentId, Long commentCounter,User author) {
+        return new CreateCommentResponseDto(commentId, commentCounter,author);
     }
 }

--- a/src/main/java/org/winey/server/domain/comment/Comment.java
+++ b/src/main/java/org/winey/server/domain/comment/Comment.java
@@ -1,0 +1,41 @@
+package org.winey.server.domain.comment;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.winey.server.domain.AuditingTimeEntity;
+import org.winey.server.domain.feed.Feed;
+import org.winey.server.domain.user.User;
+
+import javax.persistence.*;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Comment extends AuditingTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "comment_id")
+    private Long commentId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "feed_id")
+    private Feed feed;
+
+    @Column(nullable = false)
+    private String content;
+
+    @Builder
+    public Comment(User user, Feed feed, String content) {
+        this.user = user;
+        this.feed = feed;
+        this.content = content;
+    }
+
+
+}

--- a/src/main/java/org/winey/server/domain/feed/Feed.java
+++ b/src/main/java/org/winey/server/domain/feed/Feed.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.winey.server.domain.AuditingTimeEntity;
+import org.winey.server.domain.comment.Comment;
 import org.winey.server.domain.goal.Goal;
 import org.winey.server.domain.user.User;
 
@@ -36,6 +37,9 @@ public class Feed extends AuditingTimeEntity {
 
     @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, mappedBy = "feed", orphanRemoval = true)
     private List<FeedLike> feedLikes;
+
+    @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, mappedBy = "feed", orphanRemoval = true)
+    private List<Comment> comment;
 
     @Builder
     public Feed(User user, String feedTitle, String feedImage, Long feedMoney){

--- a/src/main/java/org/winey/server/domain/user/User.java
+++ b/src/main/java/org/winey/server/domain/user/User.java
@@ -4,6 +4,7 @@ import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
 import org.winey.server.domain.AuditingTimeEntity;
+import org.winey.server.domain.comment.Comment;
 import org.winey.server.domain.feed.Feed;
 import org.winey.server.domain.goal.Goal;
 import org.winey.server.domain.recommend.Recommend;
@@ -45,6 +46,9 @@ public class User extends AuditingTimeEntity {
     private List<Recommend> recommends;
     @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, mappedBy = "user", orphanRemoval = true)
     private List<Feed> feeds;
+
+    @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, mappedBy = "user", orphanRemoval = true)
+    private List<Comment> comments;
 
     @Builder
     public User(String nickname, String socialId, SocialType socialType) {

--- a/src/main/java/org/winey/server/exception/Error.java
+++ b/src/main/java/org/winey/server/exception/Error.java
@@ -46,10 +46,11 @@ public enum Error {
     /**
      * 404 NOT FOUND
      */
-    NOT_FOUND_USER_EXCEPTION(HttpStatus.NOT_FOUND, "존재하지 않는 유저입니다"),
+    NOT_FOUND_USER_EXCEPTION(HttpStatus.NOT_FOUND, "존재하지 않는 유저입니다."),
     NOT_FOUND_RECOMMEND_PAGE_EXCEPTION(HttpStatus.NOT_FOUND, "존재하지 않는 추천 위니 페이지입니다."),
-    NOT_FOUND_GOAL_EXCEPTION(HttpStatus.NOT_FOUND, "존재하지 않는 목표입니다"),
-    NOT_FOUND_FEED_EXCEPTION(HttpStatus.NOT_FOUND, "존재하지 않는 피드입니다"),
+    NOT_FOUND_GOAL_EXCEPTION(HttpStatus.NOT_FOUND, "존재하지 않는 목표입니다."),
+    NOT_FOUND_FEED_EXCEPTION(HttpStatus.NOT_FOUND, "존재하지 않는 피드입니다."),
+    NOT_FOUND_COMMENT_EXCEPTION(HttpStatus.NOT_FOUND, "존재하지 않는 댓글입니다."),
 
     /**
      * 409 CONFLICT

--- a/src/main/java/org/winey/server/exception/Success.java
+++ b/src/main/java/org/winey/server/exception/Success.java
@@ -36,6 +36,7 @@ public enum Success {
      * 204 NO CONTENT
      */
     DELETE_FEED_SUCCESS(HttpStatus.NO_CONTENT, "피드가 정상적으로 삭제되었습니다."),
+    DELETE_COMMENT_SUCCESS(HttpStatus.NO_CONTENT, "댓글이 정상적으로 삭제되었습니다."),
 
     DELETE_USER_SUCCESS(HttpStatus.NO_CONTENT, "회원 탈퇴가 정상적으로 이루어졌습니다.")
     ;

--- a/src/main/java/org/winey/server/exception/Success.java
+++ b/src/main/java/org/winey/server/exception/Success.java
@@ -29,6 +29,8 @@ public enum Success {
     CREATE_BOARD_SUCCESS(HttpStatus.CREATED, "게시물 생성이 완료됐습니다."),
     CREATE_GOAL_SUCCESS(HttpStatus.CREATED, "목표 생성이 완료됐습니다."),
     CREATE_FEED_RESPONSE_SUCCESS(HttpStatus.CREATED, "피드 반응 생성이 완료됐습니다."),
+    CREATE_COMMENT_RESPONSE_SUCCESS(HttpStatus.CREATED, "댓글 생성이 완료됐습니다."),
+
 
     /**
      * 204 NO CONTENT

--- a/src/main/java/org/winey/server/infrastructure/CommentRepository.java
+++ b/src/main/java/org/winey/server/infrastructure/CommentRepository.java
@@ -5,8 +5,16 @@ import org.winey.server.domain.comment.Comment;
 import org.winey.server.domain.feed.Feed;
 import org.winey.server.domain.feed.FeedLike;
 
+import java.util.Optional;
+
 public interface CommentRepository extends Repository<Comment,Long> {
-    int countByFeed(Feed feed);
+    Long countByFeed(Feed feed);
+
+    Optional<Comment> findByCommentId(Long feedId);
 
     void save(Comment comment);
+
+    Long deleteByCommentId(Long commentId);
+
+
 }

--- a/src/main/java/org/winey/server/infrastructure/CommentRepository.java
+++ b/src/main/java/org/winey/server/infrastructure/CommentRepository.java
@@ -1,0 +1,12 @@
+package org.winey.server.infrastructure;
+
+import org.springframework.data.repository.Repository;
+import org.winey.server.domain.comment.Comment;
+import org.winey.server.domain.feed.Feed;
+import org.winey.server.domain.feed.FeedLike;
+
+public interface CommentRepository extends Repository<Comment,Long> {
+    int countByFeed(Feed feed);
+
+    void save(Comment comment);
+}

--- a/src/main/java/org/winey/server/service/CommentService.java
+++ b/src/main/java/org/winey/server/service/CommentService.java
@@ -6,6 +6,8 @@ import org.springframework.transaction.annotation.Transactional;
 import org.winey.server.controller.response.comment.CreateCommentResponseDto;
 import org.winey.server.controller.response.feedLike.CreateFeedLikeResponseDto;
 import org.winey.server.domain.comment.Comment;
+import org.winey.server.exception.model.UnauthorizedException;
+import org.winey.server.exception.model.UnprocessableEntityException;
 import org.winey.server.infrastructure.CommentRepository;
 import org.winey.server.domain.feed.Feed;
 import org.winey.server.domain.user.User;
@@ -13,6 +15,7 @@ import org.winey.server.exception.Error;
 import org.winey.server.exception.model.NotFoundException;
 import org.winey.server.infrastructure.FeedRepository;
 import org.winey.server.infrastructure.UserRepository;
+
 
 @Service
 @RequiredArgsConstructor
@@ -35,7 +38,25 @@ public class CommentService {
                 .feed(feed)
                 .build();
         commentRepository.save(comment);
-        return CreateCommentResponseDto.of(feedId, (long) commentRepository.countByFeed(feed),user);
+        return CreateCommentResponseDto.of(comment.getCommentId(), commentRepository.countByFeed(feed),user);
+    }
+
+    @Transactional
+    public void deleteComment(Long userId, Long commentId){
+        User user = userRepository.findByUserId(userId)
+                .orElseThrow(()-> new NotFoundException(Error.NOT_FOUND_USER_EXCEPTION, Error.NOT_FOUND_USER_EXCEPTION.getMessage()));
+        Comment wantDeleteComment = commentRepository.findByCommentId(commentId)
+                .orElseThrow(()-> new NotFoundException(Error.NOT_FOUND_COMMENT_EXCEPTION, Error.NOT_FOUND_COMMENT_EXCEPTION.getMessage()));
+        Feed commentFeed = feedRepository.findByFeedId(wantDeleteComment.getFeed().getFeedId())
+                .orElseThrow(() -> new NotFoundException(Error.NOT_FOUND_FEED_EXCEPTION, Error.NOT_FOUND_FEED_EXCEPTION.getMessage()));
+
+        if (user.getUserId() != wantDeleteComment.getUser().getUserId() && user.getUserId() != commentFeed.getUser().getUserId() ){ //만약 현재 유저가 피드 주인도 아니고, 댓글 주인도 아니면?
+                throw new UnauthorizedException(Error.DELETE_UNAUTHORIZED, Error.DELETE_UNAUTHORIZED.getMessage()); //지울 수 있는 권한이 없다.
+        }
+        Long res = commentRepository.deleteByCommentId(commentId);
+        if (res != 1){
+            throw new UnprocessableEntityException(Error.UNPROCESSABLE_ENTITY_DELETE_EXCEPTION,Error.UNPROCESSABLE_ENTITY_DELETE_EXCEPTION.getMessage());
+        }
     }
 
 

--- a/src/main/java/org/winey/server/service/CommentService.java
+++ b/src/main/java/org/winey/server/service/CommentService.java
@@ -1,0 +1,42 @@
+package org.winey.server.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.winey.server.controller.response.comment.CreateCommentResponseDto;
+import org.winey.server.controller.response.feedLike.CreateFeedLikeResponseDto;
+import org.winey.server.domain.comment.Comment;
+import org.winey.server.infrastructure.CommentRepository;
+import org.winey.server.domain.feed.Feed;
+import org.winey.server.domain.user.User;
+import org.winey.server.exception.Error;
+import org.winey.server.exception.model.NotFoundException;
+import org.winey.server.infrastructure.FeedRepository;
+import org.winey.server.infrastructure.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+    private final UserRepository userRepository;
+    private final FeedRepository feedRepository;
+    private final CommentRepository commentRepository;
+
+    @Transactional
+    public CreateCommentResponseDto createComment(Long userId, Long feedId, String content) {
+        User user = userRepository.findByUserId(userId)
+                .orElseThrow(() -> new NotFoundException(Error.NOT_FOUND_USER_EXCEPTION, Error.NOT_FOUND_USER_EXCEPTION.getMessage()));
+        Feed feed = feedRepository.findByFeedId(feedId)
+                .orElseThrow(() -> new NotFoundException(Error.NOT_FOUND_FEED_EXCEPTION, Error.NOT_FOUND_FEED_EXCEPTION.getMessage()));
+
+
+        Comment comment = Comment.builder()
+                .user(user)
+                .content(content)
+                .feed(feed)
+                .build();
+        commentRepository.save(comment);
+        return CreateCommentResponseDto.of(feedId, (long) commentRepository.countByFeed(feed),user);
+    }
+
+
+}

--- a/src/main/java/org/winey/server/service/auth/AuthService.java
+++ b/src/main/java/org/winey/server/service/auth/AuthService.java
@@ -116,6 +116,7 @@ public class AuthService {
         System.out.println("Goals: " + user.getGoals());
         System.out.println("Recommends: " + user.getRecommends());
         System.out.println("Feeds: " + user.getFeeds());
+        System.out.println("Comments: "+ user.getComments());
         Long res = userRepository.deleteByUserId(userId); //res가 삭제된 컬럼의 개수 즉, 1이 아니면 뭔가 알 수 없는 에러.
         System.out.println(res + "개의 컬럼이 삭제되었습니다.");
         if (res!=1){


### PR DESCRIPTION
## 🚩 관련 이슈
- close #100 

## 📋 구현 기능 명세
- [x] 댓글 생성 기능
- [x] 댓글 삭제 기능
- [x] (기획단 요구사항 추가) 댓글 500자 제한  
- [x] 유저 삭제와 관련된 연관관계 코드 점검

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
댓글 생성 및 삭제 기능을 구현하였고, 수정은 기획단에서 생각하지 않은 부분이라고 하여 그렇게 어려울 것 같진 않지만 개발 리소스 상 그냥 생략하고 다음 api로 넘어가는게 좋을 것 같다고 생각하여 삭제까지만 구현했습니다.🙈
또한, 권한도 피드 주인이거나 댓글 주인이 아니면 댓글 삭제를 못하게 처리까지 반영해놓은 상태입니다.☺️


- 어떤 부분에 리뷰어가 집중해야 하는지
테스트는 아직 해보지않아서 merge는 테스트까지 끝나고 하도록 하겠습니다. 심심할 때 스페인에서 타코 드시면서 코드 읽어보시면 좋을 것 같아용 키키 😍

- 개발하면서 어떤 점이 궁금했는지
그 댓글 생성을 했을 때 댓글 id를 response로 알려줘야 나중에 삭제할 때 댓글 id를 클라쪽에서 넘겨줄 수 있는 것이겠죠? 그 부분이 조금 헷갈리는 것 같습니다..!

## 📸 결과물 스크린샷
<img width="815" alt="image" src="https://github.com/team-winey/Winey-Server/assets/49307946/7ff3584e-0cbf-4205-981b-787943b55d45">


## 🛠️ 테스트
- [] 테스트 아직 못함 추후 수정 예정

## 🚀 API Endpoint
- /comment/{feedId} ->create
- /comment/{commentId} -> delete
