### PR TITLE
Feat/#157 정해진 시간 지나면 자동으로 알림 삭제

### DIFF
--- a/src/main/java/org/winey/server/infrastructure/NotiRepository.java
+++ b/src/main/java/org/winey/server/infrastructure/NotiRepository.java
@@ -18,9 +18,10 @@ public interface NotiRepository extends Repository<Notification,Long>{
 
     List<Notification> findByNotiReceiverAndIsCheckedFalse(User notiReceiver);
 
-    List<Notification> findByRequestUserId(Long requestUserId);
+    Long deleteAllByNotiIdIn(List<Long> notiIds);
 
-    long countByNotiReceiverAndIsCheckedFalse(User notiReceiver);
+    List<Notification> findByIsCheckedTrueOrderByUpdatedAtAsc();
+
 
     // DELETE
     long deleteByNotiTypeAndResponseId(NotiType notiType, Long responseId);

--- a/src/main/java/org/winey/server/service/NotiService.java
+++ b/src/main/java/org/winey/server/service/NotiService.java
@@ -19,7 +19,9 @@ import org.winey.server.infrastructure.UserRepository;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Queue;
 import java.util.TimeZone;
 import java.util.stream.Collectors;
 
@@ -34,7 +36,7 @@ public class NotiService {
     public GetAllNotiResponseDto getAllNoti(Long userId) {
         User currentUser = userRepository.findByUserId(userId).orElseThrow(() -> new NotFoundException(Error.NOT_FOUND_USER_EXCEPTION, Error.NOT_FOUND_USER_EXCEPTION.getMessage()));
         List<Notification> notifications = notiRepository.findAllByNotiReceiverOrderByCreatedAtDesc(currentUser);
-        if (notifications.isEmpty()){
+        if (notifications.isEmpty()) {
             return null;
         }
         List<GetNotiResponseDto> response = notifications.stream()
@@ -50,6 +52,7 @@ public class NotiService {
                 )).collect(Collectors.toList());
         return GetAllNotiResponseDto.of(response);
     }
+
     @Transactional
     public void checkAllNoti(Long userId) {     // 내가 체크 안했던 애들을 찾아서 다 체크 true 해버리기. 특정 조건 url을 타면 ㅇㅇ
         User currentUser = userRepository.findByUserId(userId).orElseThrow(() -> new NotFoundException(Error.NOT_FOUND_USER_EXCEPTION, Error.NOT_FOUND_USER_EXCEPTION.getMessage()));
@@ -84,6 +87,31 @@ public class NotiService {
                 notification.updateLinkId(null);
                 notiRepository.save(notification);
             }
+        }
+    }
+
+    @Scheduled(cron = "0 0 2 * * *", zone = "Asia/Seoul") //혹시 모를 racing에 대비해 새벽 2시에 시작되도록 함.
+    @Transactional
+    public void deleteReadNotification() {
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+        List<Notification> notifications = notiRepository.findByIsCheckedTrueOrderByUpdatedAtAsc();
+        LocalDate today = LocalDate.now();
+        LocalDateTime now = LocalDateTime.now();
+        List<Long> deleteLists = new ArrayList<>();
+        System.out.println(now.minusDays(7)+"일 전을 기준으로 체크된 모든 알림을 지웁니다.");
+
+        for (Notification notification : notifications) {
+            if (notification.getUpdatedAt().isBefore(now.minusDays(7))) {
+                if(notification.getNotiType() != NotiType.HOWTOLEVELUP) {   //단, 레벨업 방법 알림은 제외.
+                    deleteLists.add(notification.getNotiId());
+                }
+            } else {
+                break;
+            }
+        }
+        if (!deleteLists.isEmpty()) {
+            Long res = notiRepository.deleteAllByNotiIdIn(deleteLists);
+            System.out.println(res+"개의 알림을 삭제했습니다.");
         }
     }
 


### PR DESCRIPTION
## 🚩 관련 이슈
- close #157 

## 📋 구현 기능 명세
- [x] 새벽 2시 정각에 자동으로 유저가 확인한 지 7일 지난 알림 삭제 기능 구현

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
쿼리를 하나하나 날리는 것보다 다음과 같이 ArrayList로 묶어서 쿼리 두 번으로 끝내도록 구현하였습니다.
새벽2시로 해둔 이유는 12시에 같이 실행시키면 racing이 일어나지 않을까하는 마음에 일단 안전하게 시간을 맞춰놨습니다.😹

- 어떤 부분에 리뷰어가 집중해야 하는지
사실 이와 관련하여 삭제를 할 때 메시지 큐 방식을 고안해서 생각을 해보려고 했는데 생각보다 의존성도 추가해야하고 생각할게 많아 먼저 공부하고 새 브랜치를 파서 해보는게 좋을 것 같습니다. ㅠㅠ 이번 오비 미미나 때 rabbitMQ를 생각하고 있어서 사실 같이 적용해서 해볼까했는데 다른 오비에게도 자문을 구한 결과 fcm vs 메시지 큐 이런식으로 두개를 고민하는 것으로 봐서 우리 서비스에 어떤 것을 쓰면 좋을지 생각해볼까 합니다..!
관련해서 좋은 의견 있으면 알려주세요!

- 개발하면서 어떤 점이 궁금했는지
저희 닉네임 변경했을 때 관련 알림도 수정하는 기능과 관련하여 다른 오비한테도 물어본 결과 생각보다 쿼리 날리는 횟수가 비슷할 수도 있어서 메시지 큐로 성능 최적화가 되는게 맞는 것인가에 대해서도 조금 생각을 해볼 필요가 있다는 의견을 들었습니다!☺️ 이와 관련해서 어떤 방법으로 할지 같이 고민해봤으면 좋겠습니다!😁

## 🛠️ 테스트
- [x] 테스트
