### PR TITLE
Bug/#164  중복 엔티티 발생 버그 해결시도

### DIFF
--- a/src/main/java/org/winey/server/service/NotiService.java
+++ b/src/main/java/org/winey/server/service/NotiService.java
@@ -69,7 +69,7 @@ public class NotiService {
         return notifications.size() != 0;
     }
 
-    @Scheduled(cron = "0 * * * * *", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
     @Transactional
     public void checkGoalDateNotification() {
         TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));

--- a/src/main/java/org/winey/server/service/NotiService.java
+++ b/src/main/java/org/winey/server/service/NotiService.java
@@ -69,13 +69,13 @@ public class NotiService {
         return notifications.size() != 0;
     }
 
-    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 * * * * *", zone = "Asia/Seoul")
+    @Transactional
     public void checkGoalDateNotification() {
         TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
         List<Goal> allGoals = goalRepository.findLatestGoalsForEachUser();
         LocalDate today = LocalDate.now();
         LocalDateTime now = LocalDateTime.now();
-
         for (Goal currentGoal : allGoals) {
             if (currentGoal.getTargetDate().isEqual(today.minusDays(1))) {
                 Notification notification = Notification.builder()


### PR DESCRIPTION
## 🚩 관련 이슈
- close #164 

## 📋 구현 기능 명세
- [x] @Transactional 어노테이션 추가

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
아무리 생각을 해봐도 쿼리문 자체에는 이상이 없는 것 같아서 이유를 곰곰히 생각해보았습니다. 그래서 생각을 해보니 @Transactional 어노테이션이 빠져있는 것을 고려해봤을 때 이 작업 자체가 두 번 일어난다면 충분히 가능성이 있다고 판단하여 이와 같이 수정을 해보았습니다.

- 어떤 부분에 리뷰어가 집중해야 하는지
트랜잭션 어노테이션을 사용하지 않았을 때 발생하는 문제에 대해서 조사해봤습니다.👀
동시성 문제: 여러 스레드 또는 프로세스가 동시에 동일한 데이터를 변경하려고 할 때 중복 엔티티 생성 문제가 발생할 수 있습니다. 예를 들어, 동시에 같은 데이터를 추가하려고 시도할 때 중복된 데이터가 저장될 수 있습니다.

데이터 중복 확인 누락: 데이터 중복을 확인하는 로직이 부족하거나 오류가 있는 경우 중복 엔티티 생성 문제가 발생할 수 있습니다. 데이터를 추가하기 전에 중복을 확인하거나 데이터베이스 제약 조건을 사용하여 중복을 방지하는 것이 중요합니다.

트랜잭션 경계 설정: @Transactional을 사용하지 않거나 올바르게 설정하지 않은 경우, 데이터베이스 트랜잭션이 제대로 관리되지 않을 수 있으며, 이로 인해 중복 작업이 발생할 수 있습니다.

by gpt. 따라서 충분히 시도해 볼만 하지 않나 싶습니다. 제발 해결 됐으면 ㅜㅜ😢

- 개발하면서 어떤 점이 궁금했는지
개발 하다가 보니 문득 fetch join을 사용하면 조금 더 성능을 끌어올릴 수 있지않을까라는 생각이 들었습니다. 관련해서 우리쪽 db와 관련된 최적화 방법들로 뭐가 더 있을지 고민해보겠습니다. ☺️
