### PR TITLE
[Refactor] feed 쪽 알림 로직 중복코드 제거

### DIFF
--- a/src/main/java/org/winey/server/service/FeedService.java
+++ b/src/main/java/org/winey/server/service/FeedService.java
@@ -75,58 +75,21 @@ public class FeedService {
             if (presentUser.getUserLevel().getLevelNumber() != checkUserLevelUp(presentUser)) {//userLevel 변동사항 체크, 만약에 레벨에 변동이 생겼다면? 레벨 강등 알림 생성.
                 switch (checkUserLevelUp(presentUser)){
                     case 2:
-                        Notification noti2 = Notification.builder()
-                                .notiType(NotiType.RANKUPTO2)
-                                .notiMessage(NotiType.RANKUPTO2.getType())
-                                .isChecked(false)
-                                .notiReciver(presentUser)
-                                .build();
-                        noti2.updateLinkId(null);
-                        notiRepository.save(noti2);
+                        notificationBuilderInFeed(NotiType.RANKUPTO2, presentUser);
                         break;
                     case 3:
-                        Notification noti3 = Notification.builder()
-                                .notiType(NotiType.RANKUPTO3)
-                                .notiMessage(NotiType.RANKUPTO3.getType())
-                                .isChecked(false)
-                                .notiReciver(presentUser)
-                                .build();
-                        noti3.updateLinkId(null);
-                        notiRepository.save(noti3);
+                        notificationBuilderInFeed(NotiType.RANKUPTO3, presentUser);
                         break;
                     case 4:
-                        Notification noti4 = Notification.builder()
-                                .notiType(NotiType.RANKUPTO4)
-                                .notiMessage(NotiType.RANKUPTO4.getType())
-                                .isChecked(false)
-                                .notiReciver(presentUser)
-                                .build();
-                        noti4.updateLinkId(null);
-                        notiRepository.save(noti4);
+                        notificationBuilderInFeed(NotiType.RANKUPTO4, presentUser);
                         break;
-
                 }
             }
         }
         return CreateFeedResponseDto.of(feed.getFeedId(), feed.getCreatedAt());
     }
 
-    private int checkUserLevelUp(User presentUser) {
-        int userAchievedGoals = goalRepository.countByUserAndIsAttained(presentUser, true); //Goal 중 userid가 맞고 isAttained true 개수 세기
-        if (userAchievedGoals < 1) {
-            presentUser.updateUserLevel(UserLevel.COMMONER);
-            return 1;
-        } else if (userAchievedGoals < 3) {
-            presentUser.updateUserLevel(UserLevel.KNIGHT);
-            return 2;
-        } else if (userAchievedGoals < 9) {
-            presentUser.updateUserLevel(UserLevel.ARISTOCRAT);
-            return 3;
-        } else {
-            presentUser.updateUserLevel(UserLevel.EMPEROR);
-            return 4;
-        }
-    }
+
 
     @Transactional
     public String deleteFeed(Long userId, Long feedId) {
@@ -159,24 +122,10 @@ public class FeedService {
             if (presentUser.getUserLevel().getLevelNumber() != checkUserLevelUp(presentUser)) {//userLevel 변동사항 체크, 만약에 레벨에 변동이 생겼다면? 레벨 강등 알림 생성.
                 switch (checkUserLevelUp(presentUser)){
                     case 3:
-                        Notification noti3 = Notification.builder()
-                                .notiType(NotiType.DELETERANKDOWNTO3)
-                                .notiMessage(NotiType.DELETERANKDOWNTO3.getType())
-                                .isChecked(false)
-                                .notiReciver(presentUser)
-                                .build();
-                        noti3.updateLinkId(null);
-                        notiRepository.save(noti3);
+                        notificationBuilderInFeed(NotiType.DELETERANKDOWNTO3, presentUser);
                         break;
                     case 2:
-                        Notification noti2 = Notification.builder()
-                                .notiType(NotiType.DELETERANKDOWNTO2)
-                                .notiMessage(NotiType.DELETERANKDOWNTO2.getType())
-                                .isChecked(false)
-                                .notiReciver(presentUser)
-                                .build();
-                        noti2.updateLinkId(null);
-                        notiRepository.save(noti2);
+                        notificationBuilderInFeed(NotiType.DELETERANKDOWNTO2, presentUser);
                         break;
                 }
             }
@@ -307,5 +256,33 @@ public class FeedService {
             return Math.abs(ChronoUnit.SECONDS.between(now, createdAt)) + "초전";
         }
         return "지금";
+    }
+
+    private void notificationBuilderInFeed(NotiType type, User user){
+        Notification notification = Notification.builder()
+            .notiType(type)
+            .notiMessage(type.getType())
+            .isChecked(false)
+            .notiReciver(user)
+            .build();
+        notification.updateLinkId(null);
+        notiRepository.save(notification);
+    }
+
+    private int checkUserLevelUp(User presentUser) {
+        int userAchievedGoals = goalRepository.countByUserAndIsAttained(presentUser, true); //Goal 중 userid가 맞고 isAttained true 개수 세기
+        if (userAchievedGoals < 1) {
+            presentUser.updateUserLevel(UserLevel.COMMONER);
+            return 1;
+        } else if (userAchievedGoals < 3) {
+            presentUser.updateUserLevel(UserLevel.KNIGHT);
+            return 2;
+        } else if (userAchievedGoals < 9) {
+            presentUser.updateUserLevel(UserLevel.ARISTOCRAT);
+            return 3;
+        } else {
+            presentUser.updateUserLevel(UserLevel.EMPEROR);
+            return 4;
+        }
     }
 }


### PR DESCRIPTION
## 🚩 관련 이슈
- close #181 

## 📋 구현 기능 명세
- [x] feedservice 중복 코드 개선

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
너무 로직 코드가 길어서 찾고자하는 로직 메소드가 잘 안보여서 private 메소드로 따로 빼서 개선했습니다.
그리고 Private 메소드들을 아래쪽으로 모았습니다.

- 어떤 부분에 리뷰어가 집중해야 하는지
트랜잭션 public 메소드 안에 private 메소드를 넣어주면 정상적으로 private 메서드안에 있는 트랜잭션 메소드도 잘 동작하는 것 같습니다.

- 개발하면서 어떤 점이 궁금했는지
scheduler 메소드를 테스트하려고 할 때 필요한 테스트 작업이 무엇일지 고민을 해봐야될 것 같습니다..ㅠ 그거 잘 찾아보려 리팩터링 한 것이기에..ㅠㅠ
## 📸 결과물 스크린샷
개선전
```java
if (presentUser.getUserLevel().getLevelNumber() != checkUserLevelUp(presentUser)) {//userLevel 변동사항 체크, 만약에 레벨에 변동이 생겼다면? 레벨 강등 알림 생성.
                switch (checkUserLevelUp(presentUser)){
                    case 2:
                        Notification noti2 = Notification.builder()
                                .notiType(NotiType.RANKUPTO2)
                                .notiMessage(NotiType.RANKUPTO2.getType())
                                .isChecked(false)
                                .notiReciver(presentUser)
                                .build();
                        noti2.updateLinkId(null);
                        notiRepository.save(noti2);
                        break;
                    case 3:
                        Notification noti3 = Notification.builder()
                                .notiType(NotiType.RANKUPTO3)
                                .notiMessage(NotiType.RANKUPTO3.getType())
                                .isChecked(false)
                                .notiReciver(presentUser)
                                .build();
                        noti3.updateLinkId(null);
                        notiRepository.save(noti3);
                        break;
                    case 4:
                        Notification noti4 = Notification.builder()
                                .notiType(NotiType.RANKUPTO4)
                                .notiMessage(NotiType.RANKUPTO4.getType())
                                .isChecked(false)
                                .notiReciver(presentUser)
                                .build();
                        noti4.updateLinkId(null);
                        notiRepository.save(noti4);
                        break;
```
개선 후
![image](https://github.com/team-winey/Winey-Server/assets/49307946/e0ed3efa-0f86-4714-84ba-b3dd8467cd18)

## 🛠️ 테스트
- [x] 테스트 in test db
