### PR TITLE
[Feat] 바뀐 목표체계를 반영한 과소비 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ out/
 
 ### application.yml ###
 application.yaml
+application.yml
 
 ### DS_Store
 .DS_Store

--- a/src/main/java/org/winey/server/controller/request/CreateFeedRequestDto.java
+++ b/src/main/java/org/winey/server/controller/request/CreateFeedRequestDto.java
@@ -3,6 +3,7 @@ package org.winey.server.controller.request;
 import lombok.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import javax.annotation.Nullable;
 import javax.validation.constraints.DecimalMax;
 import javax.validation.constraints.NotNull;
 
@@ -16,4 +17,10 @@ public class CreateFeedRequestDto {
     private MultipartFile feedImage;
     @NotNull @DecimalMax(value = "9999999")
     private Long feedMoney;
+    @Nullable
+    private String feedType = null;
+
+    public void setFeedType(String type) {
+        this.feedType = type;
+    }
 }

--- a/src/main/java/org/winey/server/controller/response/feed/GetFeedResponseDto.java
+++ b/src/main/java/org/winey/server/controller/response/feed/GetFeedResponseDto.java
@@ -18,6 +18,7 @@ public class GetFeedResponseDto {
     private String nickName;
     private int writerLevel;
     // 여기까쥐
+    private String feedType;
     private String feedTitle;
     private String feedImage;
     private Long feedMoney;
@@ -28,8 +29,8 @@ public class GetFeedResponseDto {
     private LocalDateTime createdAt;
 
 
-    public static GetFeedResponseDto of(Long feedId, Long userId, String nickName, int writerLevel, String feedTitle, String feedImage,
+    public static GetFeedResponseDto of(Long feedId, Long userId, String nickName, int writerLevel, String feedType, String feedTitle, String feedImage,
                                         Long feedMoney, Boolean isLiked, Long likes, Long comments, String timeAgo, LocalDateTime createdAt) {
-        return new GetFeedResponseDto(feedId, userId, nickName, writerLevel, feedTitle, feedImage, feedMoney, isLiked, likes, comments, timeAgo, createdAt);
+        return new GetFeedResponseDto(feedId, userId, nickName, writerLevel, feedType, feedTitle, feedImage, feedMoney, isLiked, likes, comments, timeAgo, createdAt);
     }
 }

--- a/src/main/java/org/winey/server/domain/feed/Feed.java
+++ b/src/main/java/org/winey/server/domain/feed/Feed.java
@@ -1,16 +1,8 @@
 package org.winey.server.domain.feed;
 
 import java.util.List;
-import javax.persistence.CascadeType;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
+import javax.persistence.*;
+
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -40,6 +32,10 @@ public class Feed extends AuditingTimeEntity {
     @Column(nullable = false)
     private String feedImage;
 
+    @Column
+    @Enumerated(EnumType.STRING)
+    private FeedType feedType;
+
     @Column(nullable = false)
     private Long feedMoney;
 
@@ -54,11 +50,12 @@ public class Feed extends AuditingTimeEntity {
     private List<Comment> comments;
 
     @Builder
-    public Feed(User user, String feedTitle, String feedImage, Long feedMoney) {
+    public Feed(User user, String feedTitle, String feedImage, Long feedMoney, FeedType feedType) {
         this.user = user;
         this.feedTitle = feedTitle;
         this.feedImage = feedImage;
         this.feedMoney = feedMoney;
+        this.feedType = feedType;
         this.goal = null;
     }
 }

--- a/src/main/java/org/winey/server/domain/feed/FeedType.java
+++ b/src/main/java/org/winey/server/domain/feed/FeedType.java
@@ -1,0 +1,23 @@
+package org.winey.server.domain.feed;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Objects;
+
+@Getter
+@AllArgsConstructor
+public enum FeedType {
+
+    SAVE("SAVE"),
+    CONSUME("CONSUME");
+
+    private final String stringVal;
+
+    public static boolean isValidFeedType(String type) {
+        for (FeedType feed : FeedType.values()) {
+            if (Objects.equals(feed.getStringVal(), type)) return true;
+        }
+        return false;
+    }
+}

--- a/src/main/java/org/winey/server/domain/user/User.java
+++ b/src/main/java/org/winey/server/domain/user/User.java
@@ -125,19 +125,13 @@ public class User extends AuditingTimeEntity {
 
     public void updateFcmIsAllowed(Boolean isAllowed){this.fcmIsAllowed = isAllowed;}
 
-    public void increaseCount() {
+    public void increaseSavedAmountAndCount(Long money) {
+        this.savedAmount += money;
         this.savedCount += 1;
     }
 
-    public void increaseSavedAmount(Long money) {
-        this.savedAmount += money;
-    }
-
-    public void decreaseCount() {
+    public void decreaseSavedAmountAndCount(Long money) {
         this.savedCount -= 1;
-    }
-
-    public void decreaseSavedAmount(Long money) {
         this.savedAmount -= money;
     }
 

--- a/src/main/java/org/winey/server/domain/user/User.java
+++ b/src/main/java/org/winey/server/domain/user/User.java
@@ -125,13 +125,16 @@ public class User extends AuditingTimeEntity {
 
     public void updateFcmIsAllowed(Boolean isAllowed){this.fcmIsAllowed = isAllowed;}
 
-    public void increaseSavedAmountAndCount(Long money) {
-        this.savedAmount += money;
+    public void increaseCount() {
         this.savedCount += 1;
     }
 
+    public void increaseSavedAmount(Long money) {
+        this.savedAmount += money;
+    }
+
     public void decreaseSavedAmountAndCount(Long money) {
-        this.savedCount -= money;
+        this.savedAmount -= money;
         this.savedCount -= 1;
     }
 

--- a/src/main/java/org/winey/server/domain/user/User.java
+++ b/src/main/java/org/winey/server/domain/user/User.java
@@ -133,9 +133,12 @@ public class User extends AuditingTimeEntity {
         this.savedAmount += money;
     }
 
-    public void decreaseSavedAmountAndCount(Long money) {
-        this.savedAmount -= money;
+    public void decreaseCount() {
         this.savedCount -= 1;
+    }
+
+    public void decreaseSavedAmount(Long money) {
+        this.savedAmount -= money;
     }
 
     public String getFcmToken() {

--- a/src/main/java/org/winey/server/exception/Error.java
+++ b/src/main/java/org/winey/server/exception/Error.java
@@ -17,6 +17,7 @@ public enum Error {
     LOGIN_SUCCESS(HttpStatus.OK, "로그인에 성공했습니다."),
     INVALID_PASSWORD_EXCEPTION(HttpStatus.BAD_REQUEST, "잘못된 비밀번호가 입력됐습니다."),
     NOT_FOUND_IMAGE_EXCEPTION(HttpStatus.BAD_REQUEST, "잘못된 이미지 파일입니다"),
+    INVALID_FEEDTYPE(HttpStatus.BAD_REQUEST, "잘못된 피드유형 입니다"),
     VALIDATION_REQUEST_MISSING_EXCEPTION(HttpStatus.BAD_REQUEST, "요청값이 입력되지 않았습니다."),
     VALIDATION_REQUEST_HEADER_MISSING_EXCEPTION(HttpStatus.BAD_REQUEST, "요청 헤더값이 입력되지 않았습니다."),
     VALIDATION_REQUEST_PARAMETER_MISSING_EXCEPTION(HttpStatus.BAD_REQUEST, "요청 파라미터값이 입력되지 않았습니다."),

--- a/src/main/java/org/winey/server/service/FeedService.java
+++ b/src/main/java/org/winey/server/service/FeedService.java
@@ -68,13 +68,10 @@ public class FeedService {
 
         feedRepository.save(feed);
 
-        // 4. 유저의 누적 피드 개수를 업데이트한다.
-        presentUser.increaseCount();
-
-        // 5. 유저의 피드 유형이 절약인 경우에는 누적 절약 금액도 업데이트한다.
-        if (Objects.equals(feedType, "SAVE")) presentUser.increaseSavedAmount(feed.getFeedMoney());
+        // 4. 유저의 피드 유형이 절약인 경우 누적 절약 금액과 누적 절약 피드 개수 업데이트한다.
+        if (Objects.equals(feedType, "SAVE")) presentUser.increaseSavedAmountAndCount(feed.getFeedMoney());
         
-        // 6. 레벨업을 체크한다.
+        // 5. 레벨업을 체크한다.
         UserLevel newUserLevel = UserLevel.calculateUserLevel(presentUser.getSavedAmount(), presentUser.getSavedCount());
 
         if (presentUser.getUserLevel() != newUserLevel) {
@@ -115,15 +112,12 @@ public class FeedService {
             throw new UnauthorizedException(Error.DELETE_UNAUTHORIZED, Error.DELETE_UNAUTHORIZED.getMessage()); // 삭제하는 사람 아니면 삭제 못함 처리.
         }
 
-        // 4. 누적 피드 개수 감소
-        presentUser.decreaseCount();
-
-        // 5. 절약 피드가 삭제되면 유저의 누적 절약 금액 업데이트
+        // 4. 절약 피드가 삭제되면 유저의 누적 절약 금액과 누적 절약 피드 개수 감소
         if (wantDeleteFeed.getFeedType() == FeedType.SAVE) {
-            presentUser.decreaseSavedAmount(wantDeleteFeed.getFeedMoney());
+            presentUser.decreaseSavedAmountAndCount(wantDeleteFeed.getFeedMoney());
         }
 
-        // 6. 레벨다운을 체크한다.
+        // 5. 레벨다운을 체크한다.
         UserLevel newUserLevel = UserLevel.calculateUserLevel(presentUser.getSavedAmount(), presentUser.getSavedCount());
 
         if (presentUser.getUserLevel() != newUserLevel) {

--- a/src/main/java/org/winey/server/service/FeedService.java
+++ b/src/main/java/org/winey/server/service/FeedService.java
@@ -60,7 +60,7 @@ public class FeedService {
         // 3. 피드를 생성한다.
         Feed feed = Feed.builder()
             .feedImage(imageUrl)
-            .feedType(FeedType.valueOf(feedType))
+            .feedType(feedType == null || feedType.isEmpty() ? null : FeedType.valueOf(feedType))
             .feedMoney(request.getFeedMoney())
             .feedTitle(request.getFeedTitle())
             .user(presentUser)
@@ -173,6 +173,7 @@ public class FeedService {
                         feed.getUser().getUserId(),
                         feed.getUser().getNickname(),
                         feed.getUser().getUserLevel().getLevelNumber(),
+                        feed.getFeedType() == null ? null : feed.getFeedType().getStringVal(),
                         feed.getFeedTitle(),
                         feed.getFeedImage(),
                         feed.getFeedMoney(),
@@ -197,6 +198,7 @@ public class FeedService {
                         myFeed.getUser().getUserId(),
                         myFeed.getUser().getNickname(),
                         myFeed.getUser().getUserLevel().getLevelNumber(),
+                        myFeed.getFeedType() == null ? null : myFeed.getFeedType().getStringVal(),
                         myFeed.getFeedTitle(),
                         myFeed.getFeedImage(),
                         myFeed.getFeedMoney(),
@@ -230,6 +232,7 @@ public class FeedService {
                 detailFeed.getUser().getUserId(),
                 detailFeed.getUser().getNickname(),
                 detailFeed.getUser().getUserLevel().getLevelNumber(),
+                detailFeed.getFeedType() == null ? null : detailFeed.getFeedType().getStringVal(),
                 detailFeed.getFeedTitle(),
                 detailFeed.getFeedImage(),
                 detailFeed.getFeedMoney(),

--- a/src/main/java/org/winey/server/service/FeedService.java
+++ b/src/main/java/org/winey/server/service/FeedService.java
@@ -115,10 +115,15 @@ public class FeedService {
             throw new UnauthorizedException(Error.DELETE_UNAUTHORIZED, Error.DELETE_UNAUTHORIZED.getMessage()); // 삭제하는 사람 아니면 삭제 못함 처리.
         }
 
-        // 4. 유저의 누적 절약 금액, 누적 절약 횟수를 업데이트한다.
-        presentUser.decreaseSavedAmountAndCount(wantDeleteFeed.getFeedMoney());
+        // 4. 누적 피드 개수 감소
+        presentUser.decreaseCount();
 
-        // 5. 레벨다운을 체크한다.
+        // 5. 절약 피드가 삭제되면 유저의 누적 절약 금액 업데이트
+        if (wantDeleteFeed.getFeedType() == FeedType.SAVE) {
+            presentUser.decreaseSavedAmount(wantDeleteFeed.getFeedMoney());
+        }
+
+        // 6. 레벨다운을 체크한다.
         UserLevel newUserLevel = UserLevel.calculateUserLevel(presentUser.getSavedAmount(), presentUser.getSavedCount());
 
         if (presentUser.getUserLevel() != newUserLevel) {


### PR DESCRIPTION
## 🚩 관련 이슈
- #210 

## 📋 구현 기능 명세
- feedType -> 피드 유형 enum 값 (과소비, 절약 피드 구분)
- dto -> CreateFeedRequestDto, GetFeedResponse 에 feedType 값 추가
- feed -> 테이블 컬럼에 feedType 추가
- Error -> 부적절한 피드유형이 request로 왔을경우에 처리할 커스텀 400에러 추가
- User -> 누적피드개수, 누적절약금액 증감이 각각 따로 일어나게 함수 분리 

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지

과소비 피드 생성을 feedType enum 추가
피드 생성, 삭제시 절약피드인 경우에만 누적절약금액 감소하게끔 분기처리
피드 엔티티 생성시 feedType 추가해서 생성되게끔 수정

- 어떤 부분에 리뷰어가 집중해야 하는지

재차 바뀐 목표체계가 피드 생성, 삭제에 따라 잘 반영되는지 풀받고 확인바랍니다
피드 조회시 피드 타입이 잘 실려오는지 확인바랍니다
.gitignore에 application.yml 추가했습니다, 절대 그럴일 없겠지만 혹시나 민감정보파일 보이면 언제든 sos 쳐주세요

## 📸 결과물 스크린샷
```java
@Pattern(regexp = "^[\\S][가-힣a-zA-Z0-9\\s]{0,20}$", message = "위니 피드 제목 형식에 맞지 않습니다.")
```

## 🛠️ 테스트
- [x] 테스트 -> 로컬테스트 완료

## 🚀 API Endpoint
- /
