### PR TITLE
[Fix] 마이페이지 API 구조 변경

### DIFF
--- a/src/main/java/org/winey/server/controller/response/user/UserResponseDto.java
+++ b/src/main/java/org/winey/server/controller/response/user/UserResponseDto.java
@@ -11,19 +11,27 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class UserResponseDto {
 
-    private Long userId;
-    private String nickname;
-    private String userLevel;
-    private Boolean fcmIsAllowed;
-    private Long accumulatedAmount;
-    private Long amountSavedHundredDays;
-    private Long amountSavedTwoWeeks;
-    private Long amountSpentTwoWeeks;
+    private UserData userData;
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class UserData {
+        private Long userId;
+        private String nickname;
+        private String userLevel;
+        private Boolean fcmIsAllowed;
+        private Long accumulatedAmount;
+        private Long amountSavedHundredDays;
+        private Long amountSavedTwoWeeks;
+        private Long amountSpentTwoWeeks;
+    }
 
     public static UserResponseDto of(Long userId, String nickname, String userLevel,
         Boolean fcmIsAllowed, Long accumulatedAmount, Long amountSavedHundredDays, Long amountSavedTwoWeeks,
         Long amountSpentTwoWeeks) {
-        return new UserResponseDto(userId, nickname, userLevel, fcmIsAllowed, accumulatedAmount,
-            amountSavedHundredDays, amountSavedTwoWeeks, amountSpentTwoWeeks);
+        UserData userData = new UserData(userId, nickname, userLevel, fcmIsAllowed, accumulatedAmount,
+                amountSavedHundredDays, amountSavedTwoWeeks, amountSpentTwoWeeks);
+        return new UserResponseDto(userData);
     }
 }


### PR DESCRIPTION
## 🚩 관련 이슈
- close #224 

## 📋 구현 기능 명세
- UserResponseDto 내부에 데이터들을 클래스로 묶어서 제공함으로써 v1 버전이랑 호환되도록 했습니다

## 📸 결과물 스크린샷
```java
@Pattern(regexp = "^[\\S][가-힣a-zA-Z0-9\\s]{0,20}$", message = "위니 피드 제목 형식에 맞지 않습니다.")
```

## 🛠️ 테스트
- [x] 테스트

## 🚀 API Endpoint
- /user
