### PR TITLE
[Refactor] user 페이지에 남은 금액 남은 횟수 추가

### DIFF
--- a/src/main/java/org/winey/server/controller/response/user/UserResponseDto.java
+++ b/src/main/java/org/winey/server/controller/response/user/UserResponseDto.java
@@ -1,5 +1,7 @@
 package org.winey.server.controller.response.user;
 
+import org.winey.server.domain.user.UserLevel;
+
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -25,14 +27,16 @@ public class UserResponseDto {
         private Long amountSavedHundredDays;
         private Long amountSavedTwoWeeks;
         private Long amountSpentTwoWeeks;
+        private Long remainingAmount;
+        private Long remainingCount;
     }
 
 
     public static UserResponseDto of(Long userId, String nickname, String userLevel,
         Boolean fcmIsAllowed, Long accumulatedAmount, Long amountSavedHundredDays, Long amountSavedTwoWeeks,
-        Long amountSpentTwoWeeks) {
+        Long amountSpentTwoWeeks, Long remainingAmount, Long remainingCount) {
         UserData userData = new UserData(userId, nickname, userLevel, fcmIsAllowed, accumulatedAmount,
-                amountSavedHundredDays, amountSavedTwoWeeks, amountSpentTwoWeeks);
+                amountSavedHundredDays, amountSavedTwoWeeks, amountSpentTwoWeeks,remainingAmount,remainingCount);
         return new UserResponseDto(userData);
     }
 }

--- a/src/main/java/org/winey/server/service/UserService.java
+++ b/src/main/java/org/winey/server/service/UserService.java
@@ -35,12 +35,23 @@ public class UserService {
         Long amountSavedTwoWeeks = feedRepository.getSavedAmountForPeriod(user, twoWeeksAgo);
         Long amountSpentTwoWeeks = feedRepository.getSpentAmountForPeriod(user, twoWeeksAgo);
 
+        UserLevel nextUserLevel = UserLevel.getNextUserLevel(user.getUserLevel());
+
+        long savedAmountOfUser = user.getSavedAmount() == null ? 0L : user.getSavedAmount();  //기존의 getSavedAmount()했을 시 null -> 0L로 처리
+        long savedCountOfUser = user.getSavedCount() == null ? 0L : user.getSavedCount();     //위와 이유 같음.
+
+        long remainingAmount = nextUserLevel == null ? 0L : nextUserLevel.getMinimumAmount() - savedAmountOfUser;
+        long remainingCount = nextUserLevel == null ? 0L : nextUserLevel.getMinimumCount() - savedCountOfUser;
+
         return UserResponseDto.of(user.getUserId(), user.getNickname(),
-            user.getUserLevel().getName(), user.getFcmIsAllowed(),
+            user.getUserLevel().getName(),
+            user.getFcmIsAllowed(),
             user.getSavedAmount() == null ? 0L : user.getSavedAmount(),
             amountSavedHundredDays == null ? 0L : amountSavedHundredDays,
             amountSavedTwoWeeks == null ? 0L : amountSavedTwoWeeks,
-            amountSpentTwoWeeks == null ? 0L : amountSpentTwoWeeks
+            amountSpentTwoWeeks == null ? 0L : amountSpentTwoWeeks,
+            remainingAmount < 0 ? 0L : remainingAmount,
+            remainingCount < 0 ? 0L : remainingCount
         );
     }
 


### PR DESCRIPTION
## 🚩 관련 이슈
- close #230 

## 📋 구현 기능 명세
- [x] user 페이지 남은 금액, 남은 횟수 추가
- [x] response에 값 추가

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
보니까 user.getSavedAmount와 count가 null인 경우를 테스트하면 500이 떠서 이유를 보니까 npe가 떠서 null처리를 안에 변수 하나를 더 써서 처리해주긴 했습니다..! 전체적인 테스트 코드 설계를 해보고 테스트 케이스 짜보는 것도 좋은 경험이 될 것 같아요!

그리고 안에 response보니까 userResponse 부분만 내부 클래스를 사용해서 구현한 것 같은데 모두 이런식으로 바꿀 것인지? 아니면 userDto를 하나 더 파서 거기다가 넣어주고 쓰는 방식으로 한다든지 통일을 하면 좋을 것 같기도 합니다..!(이건 물론 장단점 비교 후에 해보는 것이 좋지 않을까!  최근에 17버전에서 record 쓰고나니 데이터 불변성 등을 보장하는 것에 대해서 생각해보니 저런 방법도 좋은 시도라고 생각합니다.☺️


- 어떤 부분에 리뷰어가 집중해야 하는지
제가 밑에 있던 코드들을 조금 수정했는데 예외 케이스는 있을지, 테스트 케이스로는 무엇들이 있을지 고민해보면 좋을 것 같습니다.

- 개발하면서 어떤 점이 궁금했는지
흠 간단한 테스트 코드 설정.. 다 하면 브랜치파서 적용해보도록 하겠습니다!

## 📸 결과물 스크린샷
```json
{
    "code": 200,
    "message": "유저 조회 성공",
    "data": {
        "userData": {
            "userId": 151,
            "nickname": "다니",
            "userLevel": "기사",
            "fcmIsAllowed": true,
            "accumulatedAmount": 100,
            "amountSavedHundredDays": 0,
            "amountSavedTwoWeeks": 0,
            "amountSpentTwoWeeks": 0,
            "remainingAmount": 149900,
            "remainingCount": 1
        }
    }
}
```

## 🛠️ 테스트
- [x] 테스트

## 🚀 API Endpoint
- /user
