### PR TITLE
[Fix] 피드생성시 레벨업 달성여부 bool 값 responseBody에 담게끔 수정

### DIFF
--- a/src/main/java/org/winey/server/controller/response/feed/CreateFeedResponseDto.java
+++ b/src/main/java/org/winey/server/controller/response/feed/CreateFeedResponseDto.java
@@ -13,9 +13,10 @@ import java.time.LocalDateTime;
 public class CreateFeedResponseDto {
     private Long feedId;
     private LocalDateTime createdAt;
+    private Boolean levelUpgraded;
 
-    public static CreateFeedResponseDto of(Long feedId, LocalDateTime createdAt){
-        return new CreateFeedResponseDto(feedId, createdAt);
+    public static CreateFeedResponseDto of(Long feedId, LocalDateTime createdAt, Boolean levelUpgraded){
+        return new CreateFeedResponseDto(feedId, createdAt, levelUpgraded);
     }
 
 }

--- a/src/main/java/org/winey/server/service/FeedService.java
+++ b/src/main/java/org/winey/server/service/FeedService.java
@@ -74,11 +74,17 @@ public class FeedService {
         // 5. 레벨업을 체크한다.
         UserLevel newUserLevel = UserLevel.calculateUserLevel(presentUser.getSavedAmount(), presentUser.getSavedCount());
 
+        // 레벨업 달성 여부 담는 Bool 값
+        Boolean levelUpgraded = false;
+
         if (presentUser.getUserLevel() != newUserLevel) {
             // 4-1. 레벨업한다.
             presentUser.updateUserLevel(newUserLevel);
 
-            // 4-2. 레벨업 알림을 생성한다.
+            // 4-2. 레벨업 달성 여부를 true로 수정
+            levelUpgraded = true;
+
+            // 4-3. 레벨업 알림을 생성한다.
             switch (newUserLevel) {
                 case KNIGHT:
                     notificationBuilderInFeed(NotiType.RANKUPTO2, presentUser);
@@ -94,7 +100,7 @@ public class FeedService {
             }
         }
 
-        return CreateFeedResponseDto.of(feed.getFeedId(), feed.getCreatedAt());
+        return CreateFeedResponseDto.of(feed.getFeedId(), feed.getCreatedAt(), levelUpgraded);
     }
 
     @Transactional


### PR DESCRIPTION
## 🚩 관련 이슈
- close #234 

## 📋 구현 기능 명세
- 피드생성시 레벨업 달성 충족여부를 ResponseBody에 Boolean 값으로 담아 보냅니당

## 📌 PR Point
- 실제 API 응답값으로 오는지 체크
- 실제 레벨업되었을때 true로 잘오는지 확인

## 🛠️ 테스트
- [x] 테스트

## 🚀 API Endpoint
- /feed
