### PR TITLE
[Feat]#238 feature: 전체 푸시알림메시지 발송

### DIFF
--- a/src/main/java/org/winey/server/controller/BroadCastController.java
+++ b/src/main/java/org/winey/server/controller/BroadCastController.java
@@ -28,7 +28,7 @@ public class BroadCastController {
 	@PostMapping("/send-all")
 	@ResponseStatus(HttpStatus.OK)
 	@Operation(summary = "전체 유저에게 메시지 발송 API", description = "전체 유저에게 메시지를 발송합니다.")
-	public ApiResponse sendMessageToEntireUser(@RequestBody BroadCastAllUserDto broadCastAllUserDto) throws JsonProcessingException, FirebaseMessagingException {
+	public ApiResponse sendMessageToEntireUser(@RequestBody BroadCastAllUserDto broadCastAllUserDto){
 		return ApiResponse.success(Success.SEND_ENTIRE_MESSAGE_SUCCESS, broadCastService.broadAllUser(broadCastAllUserDto));
 	}
 

--- a/src/main/java/org/winey/server/controller/BroadCastController.java
+++ b/src/main/java/org/winey/server/controller/BroadCastController.java
@@ -1,0 +1,35 @@
+package org.winey.server.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import org.winey.server.common.dto.ApiResponse;
+import org.winey.server.controller.request.broadcast.BroadCastAllUserDto;
+import org.winey.server.exception.Success;
+import org.winey.server.service.BroadCastService;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.firebase.messaging.FirebaseMessagingException;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/broadcast")
+@Tag(name = "BroadCast", description = "위니 전체 푸시 API Document")
+public class BroadCastController {
+	private final BroadCastService broadCastService;
+
+	@PostMapping("/send-all")
+	@ResponseStatus(HttpStatus.OK)
+	@Operation(summary = "전체 유저에게 메시지 발송 API", description = "전체 유저에게 메시지를 발송합니다.")
+	public ApiResponse sendMessageToEntireUser(@RequestBody BroadCastAllUserDto broadCastAllUserDto) throws JsonProcessingException, FirebaseMessagingException {
+		return ApiResponse.success(Success.SEND_ENTIRE_MESSAGE_SUCCESS, broadCastService.broadAllUser(broadCastAllUserDto));
+	}
+
+}

--- a/src/main/java/org/winey/server/controller/request/broadcast/BroadCastAllUserDto.java
+++ b/src/main/java/org/winey/server/controller/request/broadcast/BroadCastAllUserDto.java
@@ -1,0 +1,15 @@
+package org.winey.server.controller.request.broadcast;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class BroadCastAllUserDto {
+	String title;
+
+	String message;
+}

--- a/src/main/java/org/winey/server/exception/Error.java
+++ b/src/main/java/org/winey/server/exception/Error.java
@@ -67,6 +67,7 @@ public enum Error {
      */
     UNPROCESSABLE_ENTITY_DELETE_EXCEPTION(HttpStatus.UNPROCESSABLE_ENTITY, "클라의 요청을 이해했지만 삭제하지 못했습니다."),
     UNPROCESSABLE_FIND_USERS(HttpStatus.UNPROCESSABLE_ENTITY, "요청을 이해했지만 유저들을 찾을 수 없었습니다."),
+    UNPROCESSABLE_SEND_TO_FIREBASE(HttpStatus.UNPROCESSABLE_ENTITY, "파이어베이스로 전송하는 과정에서 에러가 발생했습니다."),
 
     /**
      * 500 INTERNAL SERVER ERROR

--- a/src/main/java/org/winey/server/exception/Error.java
+++ b/src/main/java/org/winey/server/exception/Error.java
@@ -66,6 +66,7 @@ public enum Error {
      * 422 UNPROCESSABLE ENTITY
      */
     UNPROCESSABLE_ENTITY_DELETE_EXCEPTION(HttpStatus.UNPROCESSABLE_ENTITY, "클라의 요청을 이해했지만 삭제하지 못했습니다."),
+    UNPROCESSABLE_FIND_USERS(HttpStatus.UNPROCESSABLE_ENTITY, "요청을 이해했지만 유저들을 찾을 수 없었습니다."),
 
     /**
      * 500 INTERNAL SERVER ERROR

--- a/src/main/java/org/winey/server/exception/Success.java
+++ b/src/main/java/org/winey/server/exception/Success.java
@@ -29,6 +29,8 @@ public enum Success {
     BLOCK_USER_SUCCESS(HttpStatus.OK, "유저 차단 성공"),
     GET_ACHIEVEMENT_STATUS_SUCCESS(HttpStatus.OK, "레벨 달성 현황 조회 성공"),
 
+    SEND_ENTIRE_MESSAGE_SUCCESS(HttpStatus.OK, "전체 메시지 전송 성공"),
+
     /**
      * 201 CREATED
      */

--- a/src/main/java/org/winey/server/infrastructure/UserRepository.java
+++ b/src/main/java/org/winey/server/infrastructure/UserRepository.java
@@ -2,6 +2,7 @@ package org.winey.server.infrastructure;
 
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
+import org.springframework.lang.Nullable;
 import org.winey.server.domain.feed.Feed;
 import org.winey.server.domain.goal.Goal;
 import org.winey.server.domain.recommend.Recommend;
@@ -17,6 +18,9 @@ public interface UserRepository extends Repository<User, Long> {
 
     // READ
     Optional<User> findByUserId(Long userId);
+
+    List<User> findByFcmTokenNotNull();
+
 
     Boolean existsBySocialIdAndSocialType(String socialId, SocialType socialType);
 

--- a/src/main/java/org/winey/server/service/BroadCastService.java
+++ b/src/main/java/org/winey/server/service/BroadCastService.java
@@ -29,17 +29,21 @@ public class BroadCastService {
 
 	private final UserRepository userRepository;
 
-	public ApiResponse broadAllUser(BroadCastAllUserDto broadCastAllUserDto) throws
-		JsonProcessingException,
-		FirebaseMessagingException {
+	public ApiResponse broadAllUser(BroadCastAllUserDto broadCastAllUserDto){
 		List<User> allUser = userRepository.findByFcmTokenNotNull();
 		List<String> tokenList;
 		if (!allUser.isEmpty()){
-			tokenList = allUser.stream().map(
-				User::getFcmToken).collect(Collectors.toList());
-			System.out.println(tokenList);
-			fcmService.sendAllByTokenList(SendAllFcmDto.of(tokenList,broadCastAllUserDto.getTitle(), broadCastAllUserDto.getMessage()));
-			return ApiResponse.success(Success.SEND_ENTIRE_MESSAGE_SUCCESS, Success.SEND_ENTIRE_MESSAGE_SUCCESS.getMessage());
+			try {
+				tokenList = allUser.stream().map(
+					User::getFcmToken).collect(Collectors.toList());
+				System.out.println(tokenList);
+				fcmService.sendAllByTokenList(
+					SendAllFcmDto.of(tokenList, broadCastAllUserDto.getTitle(), broadCastAllUserDto.getMessage()));
+				return ApiResponse.success(Success.SEND_ENTIRE_MESSAGE_SUCCESS,
+					Success.SEND_ENTIRE_MESSAGE_SUCCESS.getMessage());
+			}catch (FirebaseMessagingException | JsonProcessingException e){
+				return ApiResponse.error(Error.UNPROCESSABLE_SEND_TO_FIREBASE, Error.UNPROCESSABLE_SEND_TO_FIREBASE.getMessage());
+			}
 		}
 		return ApiResponse.error(Error.UNPROCESSABLE_FIND_USERS, Error.UNPROCESSABLE_FIND_USERS.getMessage());
 	}

--- a/src/main/java/org/winey/server/service/BroadCastService.java
+++ b/src/main/java/org/winey/server/service/BroadCastService.java
@@ -1,0 +1,50 @@
+package org.winey.server.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.winey.server.common.dto.ApiResponse;
+import org.winey.server.controller.request.broadcast.BroadCastAllUserDto;
+import org.winey.server.domain.user.User;
+import org.winey.server.exception.Error;
+import org.winey.server.exception.Success;
+import org.winey.server.exception.model.CustomException;
+import org.winey.server.infrastructure.UserRepository;
+import org.winey.server.service.message.SendAllFcmDto;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.sun.net.httpserver.Authenticator;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class BroadCastService {
+
+	private final FcmService fcmService;
+
+	private final UserRepository userRepository;
+
+	public ApiResponse broadAllUser(BroadCastAllUserDto broadCastAllUserDto) throws
+		JsonProcessingException,
+		FirebaseMessagingException {
+		List<User> allUser = userRepository.findByFcmTokenNotNull();
+		List<String> tokenList;
+		if (!allUser.isEmpty()){
+			tokenList = allUser.stream().map(
+				User::getFcmToken).collect(Collectors.toList());
+			System.out.println(tokenList);
+			fcmService.sendAllByTokenList(SendAllFcmDto.of(tokenList,broadCastAllUserDto.getTitle(), broadCastAllUserDto.getMessage()));
+			return ApiResponse.success(Success.SEND_ENTIRE_MESSAGE_SUCCESS, Success.SEND_ENTIRE_MESSAGE_SUCCESS.getMessage());
+		}
+		return ApiResponse.error(Error.UNPROCESSABLE_FIND_USERS, Error.UNPROCESSABLE_FIND_USERS.getMessage());
+	}
+
+
+
+
+}

--- a/src/main/java/org/winey/server/service/FcmService.java
+++ b/src/main/java/org/winey/server/service/FcmService.java
@@ -15,16 +15,20 @@ import okhttp3.RequestBody;
 import okhttp3.Response;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
 import org.winey.server.service.message.FcmMessage;
 import org.winey.server.service.message.FcmRequestDto;
+import org.winey.server.service.message.SendAllFcmDto;
 
 import javax.annotation.PostConstruct;
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
@@ -104,13 +108,6 @@ public class FcmService{
     @Async
     public CompletableFuture<Response> sendByToken(FcmRequestDto wineyNotification) throws JsonProcessingException {
         // 메시지 만들기
-        // Message message = Message.builder()
-        //         .putData("feedId", String.valueOf(wineyNotification.getFeedId()))
-        //         .putData("notiType", String.valueOf(wineyNotification.getType()))
-        //         .putData("title", "위니 제국의 편지가 도착했어요.")
-        //         .putData("message" ,wineyNotification.getMessage())
-        //         .setToken(wineyNotification.getToken())  <- 만약 여기 destination 부분만 수정해도 될 수도 있음. 가능성 생각하기
-        //         .build();
         String jsonMessage = makeSingleMessage(wineyNotification);
         // 요청에 대한 응답을 받을 response
         Response response;
@@ -180,6 +177,65 @@ public class FcmService{
         } catch (JsonProcessingException e) {
             throw new IllegalArgumentException("JSON 처리 도중에 예외가 발생했습니다.");
         }
+    }
+
+    private List<FcmMessage> makeCustomMessages(SendAllFcmDto wineyNotification) throws JsonProcessingException {
+        try {
+            List<FcmMessage> messages = wineyNotification.getTokenList()
+                    .stream()
+                    .map(token -> FcmMessage.builder()
+                    .message(FcmMessage.Message.builder()
+                            .token(token)   // 1:1 전송 시 반드시 필요한 대상 토큰 설정
+                            .data(FcmMessage.Data.builder()
+                                    .title("위니 제국의 편지가 도착했어요.")
+                                    .message(wineyNotification.getMessage())
+                                    .feedId(null)
+                                    .notiType(null)
+                                    .build())
+                            .notification(FcmMessage.Notification.builder()
+                                    .title("위니 제국의 편지가 도착했어요.")
+                                    .body(wineyNotification.getMessage())
+                                    .build())
+                            .build()
+                    ).validateOnly(false)
+                    .build()).collect(Collectors.toList());
+            return messages;
+        } catch (Exception e) {
+            throw new IllegalArgumentException("JSON 처리 도중에 예외가 발생했습니다.");
+        }
+    }
+
+    public CompletableFuture<BatchResponse> sendAllByTokenList(SendAllFcmDto wineyNotification) throws JsonProcessingException, FirebaseMessagingException {
+        // These registration tokens come from the client FCM SDKs.
+        List<String> registrationTokens = wineyNotification.getTokenList();
+        try {
+            MulticastMessage message = MulticastMessage.builder()
+                .putData("title", wineyNotification.getTitle())
+                .putData("message", wineyNotification.getMessage())
+                .setNotification(new Notification(wineyNotification.getTitle(), wineyNotification.getMessage()))
+                .addAllTokens(registrationTokens)
+                .build();
+            BatchResponse response = FirebaseMessaging.getInstance().sendMulticast(message);
+            if (response.getFailureCount() > 0) {
+                List<SendResponse> responses = response.getResponses();
+                List<String> failedTokens = new ArrayList<>();
+                for (int i = 0; i < responses.size(); i++) {
+                    if (!responses.get(i).isSuccessful()) {
+                        // The order of responses corresponds to the order of the registration tokens.
+                        failedTokens.add(registrationTokens.get(i));
+                    }
+                }
+
+                System.out.println("List of tokens that caused failures: " + failedTokens);
+            }
+            return CompletableFuture.completedFuture(response);
+        } catch (Exception e){
+            log.info(e.getMessage());
+        }
+		return null;
+	}
+    private Notification convertToFirebaseNotification(FcmMessage.Notification customNotification) {
+        return new Notification(customNotification.getTitle(), customNotification.getBody());
     }
 
 }

--- a/src/main/java/org/winey/server/service/FcmService.java
+++ b/src/main/java/org/winey/server/service/FcmService.java
@@ -179,31 +179,31 @@ public class FcmService{
         }
     }
 
-    private List<FcmMessage> makeCustomMessages(SendAllFcmDto wineyNotification) throws JsonProcessingException {
-        try {
-            List<FcmMessage> messages = wineyNotification.getTokenList()
-                    .stream()
-                    .map(token -> FcmMessage.builder()
-                    .message(FcmMessage.Message.builder()
-                            .token(token)   // 1:1 전송 시 반드시 필요한 대상 토큰 설정
-                            .data(FcmMessage.Data.builder()
-                                    .title("위니 제국의 편지가 도착했어요.")
-                                    .message(wineyNotification.getMessage())
-                                    .feedId(null)
-                                    .notiType(null)
-                                    .build())
-                            .notification(FcmMessage.Notification.builder()
-                                    .title("위니 제국의 편지가 도착했어요.")
-                                    .body(wineyNotification.getMessage())
-                                    .build())
-                            .build()
-                    ).validateOnly(false)
-                    .build()).collect(Collectors.toList());
-            return messages;
-        } catch (Exception e) {
-            throw new IllegalArgumentException("JSON 처리 도중에 예외가 발생했습니다.");
-        }
-    }
+    // private List<FcmMessage> makeCustomMessages(SendAllFcmDto wineyNotification) throws JsonProcessingException {
+    //     try {
+    //         List<FcmMessage> messages = wineyNotification.getTokenList()
+    //                 .stream()
+    //                 .map(token -> FcmMessage.builder()
+    //                 .message(FcmMessage.Message.builder()
+    //                         .token(token)   // 1:1 전송 시 반드시 필요한 대상 토큰 설정
+    //                         .data(FcmMessage.Data.builder()
+    //                                 .title("위니 제국의 편지가 도착했어요.")
+    //                                 .message(wineyNotification.getMessage())
+    //                                 .feedId(null)
+    //                                 .notiType(null)
+    //                                 .build())
+    //                         .notification(FcmMessage.Notification.builder()
+    //                                 .title("위니 제국의 편지가 도착했어요.")
+    //                                 .body(wineyNotification.getMessage())
+    //                                 .build())
+    //                         .build()
+    //                 ).validateOnly(false)
+    //                 .build()).collect(Collectors.toList());
+    //         return messages;
+    //     } catch (Exception e) {
+    //         throw new IllegalArgumentException("JSON 처리 도중에 예외가 발생했습니다.");
+    //     }
+    // }
 
     public CompletableFuture<BatchResponse> sendAllByTokenList(SendAllFcmDto wineyNotification) throws JsonProcessingException, FirebaseMessagingException {
         // These registration tokens come from the client FCM SDKs.

--- a/src/main/java/org/winey/server/service/message/SendAllFcmDto.java
+++ b/src/main/java/org/winey/server/service/message/SendAllFcmDto.java
@@ -1,0 +1,23 @@
+package org.winey.server.service.message;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.winey.server.domain.notification.NotiType;
+
+import java.io.Serializable;
+import java.util.List;
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class SendAllFcmDto {
+    private List<String> tokenList;
+
+    private String title;
+
+    private String message;
+
+    public static SendAllFcmDto of(List<String> tokenList, String title, String message){
+        return new SendAllFcmDto(tokenList, title, message);
+    }
+}


### PR DESCRIPTION
## 🚩 관련 이슈
- close #238 

## 📋 구현 기능 명세
- [x] 전체에게 푸시알림 발송

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
fcm service에 모두 작성할 수도 있었지만, 전체적으로 fcm을 발송하거나 배치 단위로 하는 작업들을 대상으로 메소드들을 추가하는 경우가 생긴다면 리팩토링에 어려움을 겪을 것 같아서 따로 분리시켰습니다.

- 어떤 부분에 리뷰어가 집중해야 하는지
예외 케이스가 있을지를 같이 찾아줬으면 합니다. 실행을 시켰을 때 에러가 뜨는 경우들은 다음과 같았습니다.
테스트 db기준으로
1. 토큰이 null일 때
2.토큰에 test와 같이 그냥 user생성을 할때 넣어놓은 문자열로 인해
3.토큰값이 이상할때 -> 예상으로는 만료가 되거나 기기가 변경되면 다른 로직이 있는건지 이부분을 확인하기 어렵습니다.

그래서 일단 토큰이 null일 때 경우만 걸러내도록 repository단에서 걸렀고 프로덕션상황에서 이상한 문자열을 fcm으로 넣을 수 있는 가능성이 없어서 일단 처리안했습니다.

- 개발하면서 어떤 점이 궁금했는지
제가 알기로는 serializable등을 쓰는 것은 다른 서버등으로 요청할 때 그쪽 서버에서 java가 아니라 다른 언어일 경우 공통으로 쓰는 String이라든가 이런 애들은 자동으로 맵핑되지만 HashMap<>이라든가 이러한 형태를 읽을 수 없을 때 그쪽에서도 이해할 수 있도록 해주는 것으로 알고 있습니다. 그래서 이번에 만든 dto는 List를 썼기에 상관없을 것이라고 생각해서 안썼는데 제대로 이해한게 맞는건지 궁금합니다.

## 📸 결과물 스크린샷
![image](https://github.com/team-winey/Winey-Server/assets/49307946/e04c980a-94d9-41ec-becf-0493c8461cfb)



## 🛠️ 테스트
- [x] 테스트

## 🚀 API Endpoint
- /broadcast/send-all
